### PR TITLE
Add array support

### DIFF
--- a/docs/.vuepress/components/ArrayExample.vue
+++ b/docs/.vuepress/components/ArrayExample.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <SchemaForm
+      :schema="schema"
+      :value="userData"
+      @input="mergeChanges"
+    />
+
+    <p>Form Output:</p>
+    <OutputDisplay :data="userData" />
+  </div>
+</template>
+
+<script>
+import OutputDisplay from './OutputDisplay'
+import FormText from '../../../src/form-elements/FormText'
+import FormSelect from '../../../src/form-elements/FormSelect'
+import FormCheckbox from '../../../src/form-elements/FormCheckbox'
+
+const SCHEMA = [
+  {
+    component: FormText,
+    label: 'First Name',
+    model: 'firstName'
+  },
+  {
+    component: FormText,
+    label: 'Last Name',
+    model: 'lastName'
+  }
+]
+
+export default {
+  data () {
+    return {
+      userData: {}
+    }
+  },
+  computed: {
+    schema () {
+      return this.userData.isVueFan
+        ? {
+            ...SCHEMA,
+            feedback: {
+              component: FormText,
+              label: 'Gimme some feedback'
+            }
+          }
+        : SCHEMA
+    }
+  },
+  methods: {
+    mergeChanges (changes) {
+      this.userData = {
+        ...this.userData,
+        ...changes
+      }
+    }
+  }
+}
+</script>

--- a/docs/.vuepress/components/ArrayExample.vue
+++ b/docs/.vuepress/components/ArrayExample.vue
@@ -16,6 +16,7 @@ import OutputDisplay from './OutputDisplay'
 import FormText from '../../../src/form-elements/FormText'
 import FormSelect from '../../../src/form-elements/FormSelect'
 import FormCheckbox from '../../../src/form-elements/FormCheckbox'
+import SchemaForm from '../../../src/SchemaForm'
 
 const SCHEMA = [
   {
@@ -27,6 +28,21 @@ const SCHEMA = [
     component: FormText,
     label: 'Last Name',
     model: 'lastName'
+  },
+  {
+    component: SchemaForm,
+    schema: [
+      {
+        component: FormText,
+        label: 'Work address',
+        model: 'address'
+      },
+      {
+        component: FormText,
+        label: 'Work phone',
+        model: 'phone'
+      }
+    ]
   }
 ]
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@ footer: MIT Licensed | Copyright © 2019-present Damian Dulisz
 
 <SimpleExample></SimpleExample>
 
+## With Array Schema
+<ArrayExample></ArrayExample>
+
 ## V-Model Example
 
 <ExampleVModel></ExampleVModel>

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -21,7 +21,12 @@ export default {
   props: {
     schema: {
       type: [Object, Array],
-      required: true
+      required: true,
+      validator (schema) {
+        if (!Array.isArray(schema)) return true
+
+        return schema.filter(field => !field.model).length === 0
+      }
     },
     value: {
       type: Object,

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -3,12 +3,12 @@
     <slot name="beforeForm"></slot>
     <form class="schema-form">
       <component
-        v-for="(field, property) in schema"
-        :key="property"
+        v-for="field in parsedSchema"
+        :key="field.model"
         :is="field.component"
         v-bind="binds(field)"
-        :value="val(property, field)"
-        @input="update(property, $event)"
+        :value="val(field)"
+        @input="update(field.model, $event)"
       />
       <slot/>
     </form>
@@ -20,12 +20,27 @@
 export default {
   props: {
     schema: {
-      type: Object,
+      type: [Object, Array],
       required: true
     },
     value: {
       type: Object,
       required: true
+    }
+  },
+  computed: {
+    parsedSchema () {
+      if (Array.isArray(this.schema)) return this.schema
+
+      const arraySchema = []
+      for (let model in this.schema) {
+        arraySchema.push({
+          ...this.schema[model],
+          model
+        })
+      }
+
+      return arraySchema
     }
   },
   methods: {
@@ -40,12 +55,12 @@ export default {
         ? { schema: field.schema }
         : field
     },
-    val (property, field) {
-      if (field.schema && !this.value[property]) {
+    val (field) {
+      if (field.schema && !this.value[field.model]) {
         return {}
       }
 
-      return this.value[property]
+      return this.value[field.model]
     }
   }
 }

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -25,7 +25,7 @@ export default {
       validator (schema) {
         if (!Array.isArray(schema)) return true
 
-        return schema.filter(field => !field.model).length === 0
+        return schema.filter(field => !field.model && !field.schema).length === 0
       }
     },
     value: {


### PR DESCRIPTION
Adds array support to the schema property. 
Parses objects into arrays for consistency, and validates array schemas to have `model` property in children objects for v-model use