### PR TITLE
Support for display-mode added

### DIFF
--- a/docs/.vuepress/components/DisplayModeExample.vue
+++ b/docs/.vuepress/components/DisplayModeExample.vue
@@ -1,0 +1,93 @@
+<template>
+  <div>
+    <button @click="changeDisplayMode">Change Mode</button>
+    <SchemaForm
+      :schema="schema"
+      v-model="userData"
+      :display-mode="displayMode"
+    />
+
+    <OutputDisplay :data="userData" />
+  </div>
+</template>
+
+<script>
+    import OutputDisplay from './OutputDisplay'
+    import FormText from '../../../src/form-elements/FormText'
+    import FormSelect from '../../../src/form-elements/FormSelect'
+    import FormCheckbox from '../../../src/form-elements/FormCheckbox'
+
+    const SCHEMA = {
+        firstName: {
+            component: FormText,
+            label: 'First Name',
+        },
+        lastName: {
+            component: FormText,
+            label: 'Last Name',
+        },
+        email: {
+            component: FormText,
+            label: 'Your email',
+            required: true,
+            config: {
+                type: 'email'
+            }
+        },
+        favoriteThingAboutVue: {
+            component: FormSelect,
+            label: 'Favorite thing about Vue',
+            required: true,
+            options: [
+                'Ease of use',
+                'Documentation',
+                'Community'
+            ]
+        },
+        isVueFan: {
+            component: FormCheckbox,
+            label: 'Are you a Vue fan?'
+        }
+    };
+
+    export default {
+        components: { OutputDisplay },
+        data () {
+            return {
+                userData: {},
+                displayMode: 'EDIT'
+            }
+        },
+        computed: {
+            schema () {
+                return this.userData.isVueFan
+                    ? {
+                        ...SCHEMA,
+                        feedback: {
+                            component: FormText,
+                            label: 'Gimme some feedback'
+                        }
+                    }
+                    : SCHEMA
+            }
+        },
+        methods: {
+            changeDisplayMode() {
+                this.displayMode = (this.displayMode === 'EDIT') ? 'VIEW' : 'EDIT';
+            }
+        }
+    }
+</script>
+
+<style lang="stylus">
+  .steps
+    max-width: 35rem
+    text-align: left
+    margin: 0 auto 4rem
+    line-height: 1.6
+  button
+    padding: 4px 8px
+    border-radius: 3px
+    border: 1px solid #ccc
+    font-size: 1rem
+</style>

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -204,3 +204,13 @@ They must emit the `update-batch` event with an object payload that has the valu
   <MultiElementExample slot="example" />
   <<< @/docs/.vuepress/components/MultiElementExample.vue
 </SplitTab>
+
+### DisplayMode
+
+The SchemaForm can have two modes for View and Edit which will show elements based on chosen mode property.
+display-mode prop must have either of two values: `EDIT` or `VIEW` 
+
+<SplitTab>
+  <DisplayModeExample slot="example" />
+  <<< @/docs/.vuepress/components/DisplayModeExample.vue
+</SplitTab>

--- a/src/FormMixin.js
+++ b/src/FormMixin.js
@@ -8,6 +8,10 @@ export default {
     config: {
       type: Object,
       default: () => {}
+    },
+    displayMode: {
+      type: String,
+      default: () => 'EDIT'
     }
   },
   methods: {

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -8,6 +8,7 @@
         :is="field.component"
         v-bind="binds(field)"
         :value="val(field)"
+        :display-mode="displayMode"
         @input="update(field.model, $event)"
         @update-batch="updateBatch(field.model, $event)"
       />
@@ -32,6 +33,10 @@ export default {
     value: {
       type: Object,
       required: true
+    },
+    displayMode: {
+      type: String,
+      required: false
     }
   },
   computed: {

--- a/src/form-elements/FormCheckbox.vue
+++ b/src/form-elements/FormCheckbox.vue
@@ -5,6 +5,7 @@
         type="checkbox"
         :checked="value"
         @input="update($event.target.checked)"
+        :disabled="displayMode === 'VIEW'"
       >
       {{ label }}
     </label>
@@ -20,6 +21,9 @@ export default {
     label: {
       type: String,
       required: true
+    },
+    displayMode: {
+      type: String
     }
   }
 }

--- a/src/form-elements/FormSelect.vue
+++ b/src/form-elements/FormSelect.vue
@@ -3,21 +3,24 @@
     <label :for="label">
       {{ label }}
     </label>
-    <select
-      :value="value"
-      :required="required"
-      :id="label"
-      @input="update($event.target.value)"
-    >
-      <option
-        v-for="option in options"
-        :key="option"
-        :value="option"
-        :selected="option === value"
+    <div v-if="displayMode !== 'VIEW'">
+      <select
+        :value="value"
+        :required="required"
+        :id="label"
+        @input="update($event.target.value)"
       >
-        {{ option }}
-      </option>
-    </select>
+        <option
+          v-for="option in options"
+          :key="option"
+          :value="option"
+          :selected="option === value"
+        >
+          {{ option }}
+        </option>
+      </select>
+    </div>
+    <p v-else v-text="value"></p>
   </div>
 </template>
 
@@ -28,7 +31,13 @@ export default {
   mixins: [FormMixin],
   props: {
     label: { type: String, required: true },
-    options: { type: Array, required: true }
+    options: { type: Array, required: true },
+    displayMode: { type: String }
   }
 }
 </script>
+
+<style lang="stylus" scoped>
+  p
+    margin-top: 0;
+</style>

--- a/src/form-elements/FormText.vue
+++ b/src/form-elements/FormText.vue
@@ -3,13 +3,18 @@
     <label :for="label">
       {{ label }}
     </label>
-    <input
-      :value="value"
-      :type="config.type"
-      :required="required"
-      :id="label"
-      @input="update($event.target.value)"
-    >
+    <div v-if="displayMode !== 'VIEW'">
+      <input
+        :value="value"
+        :type="config.type"
+        :required="required"
+        :id="label"
+        @input="update($event.target.value)"
+      >
+    </div>
+    <div v-else>
+      <p v-text="value"></p>
+    </div>
   </div>
 </template>
 
@@ -26,7 +31,16 @@ export default {
     config: {
       type: Object,
       default: () => ({ type: 'text' })
+    },
+    displayMode: {
+      type: String,
+      default: () => 'EDIT'
     }
   }
 }
 </script>
+
+<style lang="stylus" scoped>
+  p
+    margin-top: 0;
+</style>


### PR DESCRIPTION
@marina-mosti display-mode is frequently used property when dealing with portal related projects where user would like to switch between View and Edit modes.

- added support for **display-mode** prop, can have either **EDIT** or **VIEW** as value
- input-box/ select will be shown in EDIT mode and value will be shown with ```<p></p>``` in VIEW mode, checkbox will remain disabled in VIEW mode.