### PR TITLE
FormTextArea component added to form-elements

### DIFF
--- a/docs/.vuepress/components/MultiElementExample.vue
+++ b/docs/.vuepress/components/MultiElementExample.vue
@@ -16,6 +16,7 @@ import MultiElementWrapper from '../../../src/form-elements/MultiElementWrapper'
 import FormText from '../../../src/form-elements/FormText'
 import FormSelect from '../../../src/form-elements/FormSelect'
 import FormCheckbox from '../../../src/form-elements/FormCheckbox'
+import FormTextArea from "../../../src/form-elements/FormTextArea";
 
 const SCHEMA = {
   firstName: {
@@ -32,6 +33,13 @@ const SCHEMA = {
     required: true,
     config: {
       type: 'email'
+    }
+  },
+  description: {
+    component: FormTextArea,
+    label: 'Description',
+    config: {
+      rows: 4
     }
   },
   favoriteThingAboutVue: {

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,6 +1,6 @@
 *
   box-sizing: border-box
-  
+
 .theme-default-content:not(.custom)
   max-width: 100%
 
@@ -45,3 +45,11 @@
                     5px 5px,
                     1px 1.5em
     background-repeat: no-repeat
+  textarea
+    padding: 8px 10px
+    border-radius: 3px
+    border: 1px solid #ccc
+    margin-bottom: 1rem
+    width: 100%
+    font-size: 1rem
+    resize: none

--- a/src/form-elements/FormTextArea.vue
+++ b/src/form-elements/FormTextArea.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <label :for="label">
+      {{ label }}
+    </label>
+    <textarea
+      :value="value"
+      :required="required"
+      :id="label"
+      :rows="config.rows"
+      @input="update($event.target.value)"
+    ></textarea>
+  </div>
+</template>
+
+<script>
+import FormMixin from '../FormMixin'
+
+export default {
+  mixins: [ FormMixin ],
+  props: {
+    label: {
+      type: String,
+      required: true
+    },
+    config: {
+      type: Object,
+      default: () => ({ rows: 4 })
+    }
+  }
+}
+</script>


### PR DESCRIPTION
- **FormTextArea.vue component** has been added to form-elements
- There is more probability of a 'Description' field in most of the schemas developers intend to use for which `<textarea> </textarea>` is ideal field.
- rows attribute can be passed through `config` parameter