### PR TITLE
(fix) Make data prop support Array in OutputDisplay component

### DIFF
--- a/docs/.vuepress/components/OutputDisplay.vue
+++ b/docs/.vuepress/components/OutputDisplay.vue
@@ -10,7 +10,7 @@ import VueJsonPretty from 'vue-json-pretty'
 export default {
   components: { VueJsonPretty },
   props: {
-    data: { type: Object, required: true }
+    data: { type: [Object, Array], required: true }
   }
 }
 </script>


### PR DESCRIPTION
WizardExample.vue passes the data prop as an array to OutputDisplay.vue . Since it only supports Object currently, browser console keeps throwing validation warning.

<img width="1672" alt="Screenshot 2019-10-13 at 6 30 24 PM" src="https://user-images.githubusercontent.com/19903825/66716046-a69c4c00-ede7-11e9-9d15-0a65c44a9126.png">


CC @marina-mosti 