### PR TITLE
Fix typo in SchemaForm example

### DIFF
--- a/index.md
+++ b/index.md
@@ -464,7 +464,7 @@ This is an example output from the example schema above after the user fills out
 ```javascript
 [
   {
-    fistName: 'Jane',
+    firstName: 'Jane',
     lastName: 'Doe'
   },
   {


### PR DESCRIPTION
This fixes a typo under the SchemaForm section by changing `fistName` to `firstName`.