### PR TITLE
feat: allow injecting local components into schemaform

### DIFF
--- a/index.md
+++ b/index.md
@@ -680,7 +680,7 @@ export default {
 </script>
 ```
 
-Notice that the `schema` declares the `component` property now as a `String`. This is because the generated `SchemaForm` can now register both the injected components locally.
+Notice that the `schema` declares the `component` property as a `String`. This is because the generated `SchemaForm` can now register both the injected components locally.
 
 The reasoning behind this is that locally registered components are _not_ available in sub-components, as [explained by the Vue 3 documentation](https://v3.vuejs.org/guide/component-registration.html#local-registration).
 

--- a/index.md
+++ b/index.md
@@ -160,6 +160,8 @@ Let’s assume for this example that you have a component in your project called
 In the above example, we use the component `FormText` that we imported as the value of the `component` property of each element.
 
 You can use the name of the component as a `String` instead, for example `'FormText'`, but be aware that the component needs to either be imported globally.
+
+If you need to declare your components locally, you can leverage the second parameter of the `SchemaFormFactory` component. Please refer to the [plugins](#plugins) documentation for more information on how to accomplish this.
 :::
 
 #### Array Schemas
@@ -567,6 +569,8 @@ You don't have to listen to this `submit` button's click events, as `SchemaWizar
 
 FormVueLate ships with the ability to import and use plugins to extend it's capabilities.
 
+### SchemaFormFactory
+
 In order to use a plugin with `SchemaForm`, you have to use the provided `SchemaFormFactory` function.
 
 First, import the `SchemaFormFactory` into your application.
@@ -616,6 +620,69 @@ export default {
 ```
 
 Now that we have defined a new component called `SchemaFormWithPlugins`, you can use it as you normally use any other component in your application.
+
+#### Using locally imported components
+
+The second parameter accepted by the `SchemaFormFactory` function is an `Object` with a key-value pair for component registration. This object will get merged into the `components: {}` declaration for generated `SchemaForm` component.
+
+This option will come in useful in cases where you do not want to import your form components globally, and need to declare them locally in the component that is instantiating your form.
+
+In the following example, two components `FormSelect` and `FormText` are imported locally into the file. They are injected into the `SchemaFormFactory` as the second parameter (the plugin array remains empty since no plugins are being used).
+
+```html
+<template>
+  <div id="app">
+    <SchemaForm :schema="schema" v-model="form" />
+  </div>
+</template>
+
+<script>
+import { ref, markRaw } from "vue"
+import { SchemaFormFactory } from "formvuelate"
+import FormText from "@/components/FormText"
+import FormSelect from "@/components/FormSelect"
+
+markRaw(FormSelect)
+markRaw(FormText)
+
+// Declare FormText and FormSelect as local components
+const factory = SchemaFormFactory([], { FormText, FormSelect })
+
+export default {
+  name: "App",
+  components: { SchemaForm: factory },
+  setup () {
+    const form = ref({
+      name: '',
+      pet: 'cat'
+    })
+
+    // We can now declare our `component` property as a string, since
+    // the component will be registered locally within the SchemaForm component
+    const schema = ref({
+      name: {
+        component: 'FormText',
+        label: 'Your name'
+      },
+      pet: {
+        component: 'FormSelect',
+        label: 'Your pet',
+        options: ['cat', 'dog']
+      }
+    })
+
+    return {
+      form,
+      schema,
+    }
+  },
+}
+</script>
+```
+
+Notice that the `schema` declares the `component` property now as a `String`. This is because the generated `SchemaForm` can now register both the injected components locally.
+
+The reasoning behind this is that locally registered components are _not_ available in sub-components, as [explained by the Vue 3 documentation](https://v3.vuejs.org/guide/component-registration.html#local-registration).
 
 ### Vuelidate Plugin
 

--- a/src/SchemaFormFactory.js
+++ b/src/SchemaFormFactory.js
@@ -1,6 +1,6 @@
 import SchemaForm from './SchemaForm'
 
-export default function SchemaFormFactory (plugins = []) {
+export default function SchemaFormFactory (plugins = [], components = null) {
   // Copy the original SchemaForm setup
   const originalSetup = SchemaForm.setup
 
@@ -23,6 +23,10 @@ export default function SchemaFormFactory (plugins = []) {
 
   return {
     ...SchemaForm,
+    components: {
+      ...SchemaForm.components,
+      ...components
+    },
     // Return a customized setup function with plugins
     // as the new SchemaForm setup
     setup

--- a/tests/unit/SchemaFormFactory.spec.js
+++ b/tests/unit/SchemaFormFactory.spec.js
@@ -10,6 +10,16 @@ const emit = jest.fn()
 const attrs = {}
 const context = { emit, attrs }
 
+const FormText = {
+  template: '<input/>',
+  props: ['label']
+}
+
+const FormSelect = {
+  template: '<select />',
+  props: ['label', 'options']
+}
+
 let warn
 
 describe('SchemaFormFactory', () => {
@@ -61,5 +71,16 @@ describe('SchemaFormFactory', () => {
       context
     )
     expect(paramFn).toEqualFunction(SchemaForm.setup(props, context))
+  })
+
+  it('passes components to be registered to the output SchemaForm', () => {
+    const factory = SchemaFormFactory([], {
+      FormText, FormSelect
+    })
+
+    expect(factory.components).toEqual({
+      FormText,
+      FormSelect
+    })
   })
 })


### PR DESCRIPTION
Allows injecting components and merging them with the `components` prop of the SchemaForm.
Addresses #144 

ie:

```js
const factory = SchemaFormFactory([], { FormText, FormSelect })
```

Test app

```html
<template>
  <div id="app">
    <SchemaForm :schema="schema" v-model="form" />
  </div>
</template>

<script>
import { ref, markRaw, computed } from "vue";
import SchemaFormFactory from "@/components/SchemaFormFactory";
import FormText from "@/components/FormText";
import FormSelect from "@/components/FormSelect";

markRaw(FormSelect);
markRaw(FormText);

const factory = SchemaFormFactory([], { FormText, FormSelect })

export default {
  name: "App",
  components: { SchemaForm: factory },
  setup () {
    const form = ref({
      type: "A",
      aField: "",
      bField: "",
    });

    const schema = computed(() => {
      return form.value.type === "A"
        ? {
          type: {
            component: 'FormSelect',
            label: "Schema A or B?",
            options: ["A", "B"],
          },
          aField: {
            component: 'FormText',
            label: "a field",
          },
          nested: {
            component: factory,
            schema: {
              aNested: {
                component: 'FormText',
                label: "a nested",
              },
              aNestedTwo: {
                component: 'FormText',
                label: "a nested two",
              }
            }
          }
        }
        : {
          type: {
            component: 'FormSelect',
            label: "Schema A or B?",
            options: ["A", "B"],
          },
          bField: {
            component: 'FormText',
            label: "b field",
          },
        };
    });

    return {
      form,
      schema,
    };
  },
};
</script>
```