### PR TITLE
Improve eslint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,8 +28,7 @@ module.exports = {
   overrides: [
     {
       files: [
-        '**/__tests__/*.{j,t}s?(x)',
-        '**/tests/unit/**/*.spec.{j,t}s?(x)'
+        '**/tests/unit/**/*.spec.js'
       ],
       env: {
         jest: true

--- a/tests/unit/.eslintrc.js
+++ b/tests/unit/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  env: {
-    jest: true
-  }
-}


### PR DESCRIPTION
The eslint config file in the tests directory is not needed
since the same thing is specified in the root `eslint.config`
