### PR TITLE
fix #187: allow multiple sub-schemas per nesting level

### DIFF
--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -73,7 +73,7 @@ export default {
   setup (props, { emit, attrs }) {
     const { behaveLikeParentSchema, hasParentSchema } = useParentSchema()
 
-    const { schema } = useInjectedSchema(props)
+    const { schema } = useInjectedSchema(props, behaveLikeParentSchema)
     const { parsedSchema } = useParsedSchema(schema, attrs.model)
 
     useFormModel(props, parsedSchema)

--- a/src/features/InjectedSchema.js
+++ b/src/features/InjectedSchema.js
@@ -1,11 +1,11 @@
 import { inject, provide, toRefs } from 'vue'
 import { INJECTED_SCHEMA, SCHEMA_MODEL_PATH } from '../utils/constants'
 
-export default function useInjectedSchema (props) {
+export default function useInjectedSchema (props, behaveLikeParentSchema) {
   const { schema } = toRefs(props)
 
   let injectedSchema = inject(INJECTED_SCHEMA, false)
-  if (!injectedSchema) {
+  if (behaveLikeParentSchema) {
     // Only the top level schema form should inject the schema
     // That way we dont have to worry about injecting the prop down into
     // sub schemas

--- a/tests/unit/SchemaForm.spec.js
+++ b/tests/unit/SchemaForm.spec.js
@@ -157,6 +157,53 @@ describe('SchemaForm', () => {
     })
   })
 
+  it('renders a form with multiple nested schemas at the same nesting level', () => {
+    const nestedSchema = {
+      work: {
+        component: SchemaForm,
+        schema: {
+          details: {
+            component: SchemaForm,
+            schema: {
+              position: {
+                component: FormText,
+                label: 'Work position'
+              },
+              employees: {
+                component: FormSelect,
+                label: 'Number of employees',
+                options: [
+                  '1', '2', '3', '4+'
+                ]
+              }
+            }
+          },
+          moreDetails: {
+            component: SchemaForm,
+            schema: {
+              department: {
+                component: FormText,
+                label: 'Department'
+              },
+              hours: {
+                component: FormSelect,
+                label: 'Hours per shift',
+                options: [
+                  '1', '2', '3', '4+'
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const wrapper = mount(SchemaWrapperFactory(nestedSchema))
+
+    expect(wrapper.findAllComponents(FormText)).toHaveLength(2)
+    expect(wrapper.findAllComponents(FormSelect)).toHaveLength(2)
+  })
+
   describe('a11y', () => {
     it('injects a unique id to each component', () => {
       const schema = {


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This prevents "Maximum call stack" errors when there are multiple adjacent sub-schemas at the same level of nesting. Not sure if this is considered a new feature, but I certainly need it to work, since that's what my form data looks like. It is also useful for delineating different sections of the form (even creating form section titles with pseudo-elements in css, for instance)
