### PR TITLE
feat: added slot binds to the base form schema

### DIFF
--- a/docs/3.x/src/guide/veevalidate.md
+++ b/docs/3.x/src/guide/veevalidate.md
@@ -381,7 +381,7 @@ export default {
 ## SchemaForm slot props
 
 ::: warning Important
-This feature is only available in FormVuelate <Badge text="3.2" type="warning" vertical="middle" /> and @formvuelate/plugin-vee-validate <Badge text="2.3" type="warning" vertical="middle" />
+This feature is available starting on FormVuelate <Badge text="3.2" type="warning" vertical="middle" /> and @formvuelate/plugin-vee-validate <Badge text="2.3" type="warning" vertical="middle" />
 :::
 
 You can access the form-level validation state by using either `afterForm` or `beforeForm` slot prop named `validation` on the `SchemaForm` component. Read more about [available slots](/guide/schema-form.md#slots).

--- a/docs/3.x/src/guide/veevalidate.md
+++ b/docs/3.x/src/guide/veevalidate.md
@@ -384,7 +384,7 @@ export default {
 This feature is only available in FormVuelate <Badge text="3.2" type="warning" vertical="middle" /> and @formvuelate/plugin-vee-validate <Badge text="2.3" type="warning" vertical="middle" />
 :::
 
-You can access the form-level validation state by using either `afterForm` or `beforeForm` slot prop named `validation` on the `SchemaForm` component. Read more about [available slots](/guide/schema-form#slots).
+You can access the form-level validation state by using either `afterForm` or `beforeForm` slot prop named `validation` on the `SchemaForm` component. Read more about [available slots](/guide/schema-form.md#slots).
 
 The form-level `validation` object contains the following properties:
 
@@ -419,6 +419,8 @@ The following are a few common examples for behaviors implemented with the form-
   </template>
 </SchemaForm>
 ```
+
+Learn more about [accessible disabling of form buttons](https://css-tricks.com/making-disabled-buttons-more-inclusive/)
 
 **Display spinner or loading state when the form is submitting**
 

--- a/docs/3.x/src/guide/veevalidate.md
+++ b/docs/3.x/src/guide/veevalidate.md
@@ -422,7 +422,7 @@ The following are a few common examples for behaviors implemented with the form-
 
 **Display spinner or loading state when the form is submitting**
 
-```vue
+```html
 <SchemaForm :schema="schema">
   <template #afterForm="{ validation }">
     <button :class="{ 'is-submitting': validation.isSubmitting }">Submit</button>

--- a/docs/3.x/src/guide/veevalidate.md
+++ b/docs/3.x/src/guide/veevalidate.md
@@ -380,7 +380,11 @@ export default {
 
 ## SchemaForm slot props
 
-You can access the form-level validation state by using either `afterForm` or `beforeForm` slot prop named `validation` on the `SchemaForm` component.
+::: warning Important
+This feature is only available in FormVuelate <Badge text="3.2" type="warning" vertical="middle" /> and @formvuelate/plugin-vee-validate <Badge text="2.3" type="warning" vertical="middle" />
+:::
+
+You can access the form-level validation state by using either `afterForm` or `beforeForm` slot prop named `validation` on the `SchemaForm` component. Read more about [available slots](/guide/schema-form#slots).
 
 The form-level `validation` object contains the following properties:
 

--- a/docs/3.x/src/guide/veevalidate.md
+++ b/docs/3.x/src/guide/veevalidate.md
@@ -1,6 +1,7 @@
 ---
 sidebarDepth: 3
 ---
+
 # Vee-Validate Plugin
 
 [Vee-Validate Plugin's Repo](https://github.com/formvuelate/formvuelate-plugin-vee-validate).
@@ -24,14 +25,14 @@ npm i vee-validate@next @formvuelate/plugin-vee-validate
 To use the plugin, import and pass it to the `SchemaFormFactory`. This creates a `SchemaForm` component with validation capabilities.
 
 ```js
-import { SchemaFormFactory } from 'formvuelate'
-import VeeValidatePlugin from '@formvuelate/plugin-vee-validate'
+import { SchemaFormFactory } from "formvuelate";
+import VeeValidatePlugin from "@formvuelate/plugin-vee-validate";
 
 const SchemaFormWithValidation = SchemaFormFactory([
   VeeValidatePlugin({
     // plugin configuration here
   })
-])
+]);
 ```
 
 Now that the component is created, you can register it and use it in your template:
@@ -39,21 +40,19 @@ Now that the component is created, you can register it and use it in your templa
 ```html
 <template>
   <div id="app">
-    <SchemaFormWithValidation
-      :schema="mySchema"
-    />
+    <SchemaFormWithValidation :schema="mySchema" />
   </div>
 </template>
 
 <script>
-export default {
-  components: {
-    SchemaFormWithValidation
-  },
-  setup () {
-    [...]
+  export default {
+    components: {
+      SchemaFormWithValidation
+    },
+    setup () {
+      [...]
+    }
   }
-}
 </script>
 ```
 
@@ -75,32 +74,29 @@ You can opt-in to any of these properties or to the entire `validation` object. 
 ```html
 <template>
   <div>
-    <input
-      :value="modelValue"
-      @input="update($event.target.value)"
-    >
+    <input :value="modelValue" @input="update($event.target.value)" />
     <span>{{ validation.errorMessage }}</span>
   </div>
 </template>
 
 <script>
-export default {
-  props: {
-    // other props
-    modelValue: {
-      required: true
+  export default {
+    props: {
+      // other props
+      modelValue: {
+        required: true
+      },
+      validation: {
+        type: Object,
+        default: () => ({})
+      }
     },
-    validation: {
-      type: Object,
-      default: () => ({})
+    methods: {
+      update(value) {
+        this.$emit("update:modelValue", value);
+      }
     }
-  },
-  methods: {
-    update (value) {
-      this.$emit('update:modelValue', value)
-    }
-  }
-}
+  };
 </script>
 ```
 
@@ -117,25 +113,25 @@ In this case, we set it using the validation object's `setTouched` method as sho
       :value="modelValue"
       @input="update($event.target.value)"
       @blur="onBlur"
-    >
+    />
     <span v-if="validation.meta.touched">{{ validation.errorMessage }}</span>
   </div>
 </template>
 
 <script>
-export default {
-  props: {
-    // ...
-  },
-  methods: {
-    update (value) {
-      this.$emit('update:modelValue', value)
+  export default {
+    props: {
+      // ...
     },
-    onBlur() {
-      this.validation.setTouched(true);
+    methods: {
+      update(value) {
+        this.$emit("update:modelValue", value);
+      },
+      onBlur() {
+        this.validation.setTouched(true);
+      }
     }
-  }
-}
+  };
 </script>
 ```
 
@@ -160,11 +156,11 @@ const SchemaFormWithValidation = SchemaFormFactory([
   VeeValidatePlugin({
     mapProps(validation) {
       return {
-        errorMessage: validation.errorMessage,
-      }
+        errorMessage: validation.errorMessage
+      };
     }
   })
-])
+]);
 ```
 
 Now your component definition can accept the `errorMessage` prop instead of the entire `validation` object.
@@ -176,18 +172,18 @@ const SchemaFormWithValidation = SchemaFormFactory([
   VeeValidatePlugin({
     mapProps(validation, el) {
       // If the field is the `FormText` component, send the entire validation object
-      if (el.component.name === 'FormText') {
+      if (el.component.name === "FormText") {
         return {
           validation
-        }
+        };
       }
       // Otherwise send the error message only
       return {
         errorMessage: validation.errorMessage
-      }
+      };
     }
   })
-])
+]);
 ```
 
 ## Defining Validation Rules
@@ -203,37 +199,35 @@ The "field-level" approach allows to you add a `validations` property to your fi
 Here is an example of a schema that uses all the possible `validations` value types:
 
 ```js
-import * as yup from 'yup';
+import * as yup from "yup";
 
 const schema = {
   email: {
     component: FormText,
-    label: 'Email',
+    label: "Email",
     // Globally defined rules
-    validations: 'required|email'
+    validations: "required|email"
   },
   password: {
     component: FormText,
-    label: 'Password',
+    label: "Password",
     // Validation functions
-    validations: (value) => value && value.length > 6
+    validations: value => value && value.length > 6
   },
   fullName: {
     component: FormText,
-    label: 'Full Name',
+    label: "Full Name",
     // yup validations
     validations: yup.string().required()
   }
-}
+};
 ```
 
 Then you can use the schema in your template
 
 ```html
 <div id="app">
-  <SchemaFormWithPlugin
-    :schema="schema"
-  />
+  <SchemaFormWithPlugin :schema="schema" />
 </div>
 ```
 
@@ -254,33 +248,39 @@ This example uses `yup` to define validation schemas for your forms.
 </template>
 
 <script>
-import * as yup from 'yup';
+  import * as yup from "yup";
 
-export default {
-  components: {
-    SchemaFormWithValidation
-  },
-  setup () {
-    const schema = ref([
-      // Fields without the `validation` prop
-    ])
+  export default {
+    components: {
+      SchemaFormWithValidation
+    },
+    setup() {
+      const schema = ref([
+        // Fields without the `validation` prop
+      ]);
 
-    const formData = ref({})
-    useSchemaForm(formData)
+      const formData = ref({});
+      useSchemaForm(formData);
 
-    // The validation schema
-    const validationSchema = yup.object().shape({
-      email: yup.string().email().required(),
-      password: yup.string().min(5).required(),
-      fullName: yup.string().required(),
-    })
+      // The validation schema
+      const validationSchema = yup.object().shape({
+        email: yup
+          .string()
+          .email()
+          .required(),
+        password: yup
+          .string()
+          .min(5)
+          .required(),
+        fullName: yup.string().required()
+      });
 
-    return {
-      schema,
-      validationSchema
+      return {
+        schema,
+        validationSchema
+      };
     }
-  }
-}
+  };
 </script>
 ```
 
@@ -290,10 +290,7 @@ The `VeeValidatePlugin` automatically handles `SchemaForm` submits, and triggers
 
 ```html
 <template>
-  <SchemaForm
-    @submit="onSubmit"
-    :schema="schema"
-  >
+  <SchemaForm @submit="onSubmit" :schema="schema">
     <template #afterForm>
       <button>Submit</button>
     </template>
@@ -311,10 +308,7 @@ You can provide initial validation state to the `SchemaForm`, to set initial err
 
 ```html
 <template>
-  <SchemaForm
-    :schema="schema"
-    :initial-errors="initialErrors"
-  >
+  <SchemaForm :schema="schema" :initial-errors="initialErrors">
     <template #afterForm>
       <button>Submit</button>
     </template>
@@ -322,26 +316,26 @@ You can provide initial validation state to the `SchemaForm`, to set initial err
 </template>
 
 <script>
-export default {
-  setup() {
-    const schema = ref([
-      // schema...
-    ])
+  export default {
+    setup() {
+      const schema = ref([
+        // schema...
+      ]);
 
-    const formData = ref({})
-    useSchemaForm(formData)
+      const formData = ref({});
+      useSchemaForm(formData);
 
-    const initialErrors = {
-      email: 'This email is already taken',
-      password: 'Password must be at least 8 characters long'
+      const initialErrors = {
+        email: "This email is already taken",
+        password: "Password must be at least 8 characters long"
+      };
+
+      return {
+        schema,
+        initialErrors
+      };
     }
-
-    return {
-      schema,
-      initialErrors
-    }
-  }
-};
+  };
 </script>
 ```
 
@@ -351,10 +345,7 @@ You can provide `initial-touched` prop to set the initial `touched` meta flags f
 
 ```html
 <template>
-  <SchemaForm
-    :schema="schema"
-    :initial-touched="initialTouched"
-  >
+  <SchemaForm :schema="schema" :initial-touched="initialTouched">
     <template #afterForm>
       <button>Submit</button>
     </template>
@@ -362,27 +353,53 @@ You can provide `initial-touched` prop to set the initial `touched` meta flags f
 </template>
 
 <script>
-export default {
-  setup() {
-    const schema = ref([
-      // schema...
-    ])
+  export default {
+    setup() {
+      const schema = ref([
+        // schema...
+      ]);
 
-    const formData = ref({})
-    useSchemaForm(formData)
+      const formData = ref({});
+      useSchemaForm(formData);
 
-    const initialTouched = {
-      email: true,
-      password: false
+      const initialTouched = {
+        email: true,
+        password: false
+      };
+
+      return {
+        formData,
+        schema,
+        initialErrors,
+        initialTouched
+      };
     }
-
-    return {
-      formData,
-      schema,
-      initialErrors,
-      initialTouched,
-    }
-  }
-};
+  };
 </script>
+```
+
+## SchemaForm slot props
+
+You can access the form-level validation state by using either `afterForm` or `beforeForm` slot prop named `validation` on the `SchemaForm` component.
+
+The form-level `validation` object contains the following properties:
+
+- `isSubmitting`: Indicates if the form is being submitted
+- `submitCount`: Indicates the number of submission attempts
+- `values`: A record object containing fields/values pairs
+- `errors`: A record object containing field/error pairs
+- `meta`: The [form meta](https://vee-validate.logaretm.com/v4/guide/components/validation#form-level-meta) object.
+
+```html
+<template>
+  <SchemaForm @submit="onSubmit" :schema="schema">
+    <template #afterForm="{ validation }">
+      <span>Form is submitting: {{ validation.isSubmitting }}</span>
+      <span>Attempted submits: {{ validation.submitCount }}</span>
+      <span>Values: {{ validation.values }}</span>
+      <span>Errors: {{ validation.errors }}</span>
+      <span>Metadata: {{ validation.meta }}</span>
+    </template>
+  </SchemaForm>
+</template>
 ```

--- a/docs/3.x/src/guide/veevalidate.md
+++ b/docs/3.x/src/guide/veevalidate.md
@@ -25,14 +25,14 @@ npm i vee-validate@next @formvuelate/plugin-vee-validate
 To use the plugin, import and pass it to the `SchemaFormFactory`. This creates a `SchemaForm` component with validation capabilities.
 
 ```js
-import { SchemaFormFactory } from 'formvuelate';
-import VeeValidatePlugin from '@formvuelate/plugin-vee-validate';
+import { SchemaFormFactory } from 'formvuelate'
+import VeeValidatePlugin from '@formvuelate/plugin-vee-validate'
 
 const SchemaFormWithValidation = SchemaFormFactory([
   VeeValidatePlugin({
     // plugin configuration here
   })
-]);
+])
 ```
 
 Now that the component is created, you can register it and use it in your template:
@@ -92,11 +92,11 @@ export default {
     }
   },
   methods: {
-    update(value) {
-      this.$emit('update:modelValue', value);
+    update (value) {
+      this.$emit('update:modelValue', value)
     }
   }
-};
+}
 </script>
 ```
 
@@ -124,14 +124,14 @@ export default {
     // ...
   },
   methods: {
-    update(value) {
-      this.$emit('update:modelValue', value);
+    update (value) {
+      this.$emit('update:modelValue', value)
     },
-    onBlur() {
-      this.validation.setTouched(true);
+    onBlur () {
+      this.validation.setTouched(true)
     }
   }
-};
+}
 </script>
 ```
 
@@ -154,13 +154,13 @@ In the following example, the `errorMessage` is extracted to it's own prop.
 ```js
 const SchemaFormWithValidation = SchemaFormFactory([
   VeeValidatePlugin({
-    mapProps(validation) {
+    mapProps (validation) {
       return {
         errorMessage: validation.errorMessage
-      };
+      }
     }
   })
-]);
+])
 ```
 
 Now your component definition can accept the `errorMessage` prop instead of the entire `validation` object.
@@ -175,15 +175,15 @@ const SchemaFormWithValidation = SchemaFormFactory([
       if (el.component.name === 'FormText') {
         return {
           validation
-        };
+        }
       }
       // Otherwise send the error message only
       return {
         errorMessage: validation.errorMessage
-      };
+      }
     }
   })
-]);
+])
 ```
 
 ## Defining Validation Rules
@@ -199,7 +199,7 @@ The "field-level" approach allows to you add a `validations` property to your fi
 Here is an example of a schema that uses all the possible `validations` value types:
 
 ```js
-import * as yup from 'yup';
+import * as yup from 'yup'
 
 const schema = {
   email: {
@@ -220,7 +220,7 @@ const schema = {
     // yup validations
     validations: yup.string().required()
   }
-};
+}
 ```
 
 Then you can use the schema in your template
@@ -248,7 +248,7 @@ This example uses `yup` to define validation schemas for your forms.
 </template>
 
 <script>
-import * as yup from 'yup';
+import * as yup from 'yup'
 
 export default {
   components: {
@@ -257,10 +257,10 @@ export default {
   setup() {
     const schema = ref([
       // Fields without the `validation` prop
-    ]);
+    ])
 
-    const formData = ref({});
-    useSchemaForm(formData);
+    const formData = ref({})
+    useSchemaForm(formData)
 
     // The validation schema
     const validationSchema = yup.object().shape({
@@ -273,14 +273,14 @@ export default {
         .min(5)
         .required(),
       fullName: yup.string().required()
-    });
+    })
 
     return {
       schema,
       validationSchema
-    };
+    }
   }
-};
+}
 </script>
 ```
 
@@ -320,22 +320,22 @@ export default {
   setup() {
     const schema = ref([
       // schema...
-    ]);
+    ])
 
-    const formData = ref({});
-    useSchemaForm(formData);
+    const formData = ref({})
+    useSchemaForm(formData)
 
     const initialErrors = {
       email: 'This email is already taken',
       password: 'Password must be at least 8 characters long'
-    };
+    }
 
     return {
       schema,
       initialErrors
-    };
+    }
   }
-};
+}
 </script>
 ```
 
@@ -357,24 +357,24 @@ export default {
   setup() {
     const schema = ref([
       // schema...
-    ]);
+    ])
 
-    const formData = ref({});
-    useSchemaForm(formData);
+    const formData = ref({})
+    useSchemaForm(formData)
 
     const initialTouched = {
       email: true,
       password: false
-    };
+    }
 
     return {
       formData,
       schema,
       initialErrors,
       initialTouched
-    };
+    }
   }
-};
+}
 </script>
 ```
 

--- a/docs/3.x/src/guide/veevalidate.md
+++ b/docs/3.x/src/guide/veevalidate.md
@@ -25,8 +25,8 @@ npm i vee-validate@next @formvuelate/plugin-vee-validate
 To use the plugin, import and pass it to the `SchemaFormFactory`. This creates a `SchemaForm` component with validation capabilities.
 
 ```js
-import { SchemaFormFactory } from "formvuelate";
-import VeeValidatePlugin from "@formvuelate/plugin-vee-validate";
+import { SchemaFormFactory } from 'formvuelate';
+import VeeValidatePlugin from '@formvuelate/plugin-vee-validate';
 
 const SchemaFormWithValidation = SchemaFormFactory([
   VeeValidatePlugin({
@@ -45,14 +45,14 @@ Now that the component is created, you can register it and use it in your templa
 </template>
 
 <script>
-  export default {
-    components: {
-      SchemaFormWithValidation
-    },
-    setup () {
-      [...]
-    }
+export default {
+  components: {
+    SchemaFormWithValidation
+  },
+  setup () {
+    [...]
   }
+}
 </script>
 ```
 
@@ -80,23 +80,23 @@ You can opt-in to any of these properties or to the entire `validation` object. 
 </template>
 
 <script>
-  export default {
-    props: {
-      // other props
-      modelValue: {
-        required: true
-      },
-      validation: {
-        type: Object,
-        default: () => ({})
-      }
+export default {
+  props: {
+    // other props
+    modelValue: {
+      required: true
     },
-    methods: {
-      update(value) {
-        this.$emit("update:modelValue", value);
-      }
+    validation: {
+      type: Object,
+      default: () => ({})
     }
-  };
+  },
+  methods: {
+    update(value) {
+      this.$emit('update:modelValue', value);
+    }
+  }
+};
 </script>
 ```
 
@@ -119,19 +119,19 @@ In this case, we set it using the validation object's `setTouched` method as sho
 </template>
 
 <script>
-  export default {
-    props: {
-      // ...
+export default {
+  props: {
+    // ...
+  },
+  methods: {
+    update(value) {
+      this.$emit('update:modelValue', value);
     },
-    methods: {
-      update(value) {
-        this.$emit("update:modelValue", value);
-      },
-      onBlur() {
-        this.validation.setTouched(true);
-      }
+    onBlur() {
+      this.validation.setTouched(true);
     }
-  };
+  }
+};
 </script>
 ```
 
@@ -172,7 +172,7 @@ const SchemaFormWithValidation = SchemaFormFactory([
   VeeValidatePlugin({
     mapProps(validation, el) {
       // If the field is the `FormText` component, send the entire validation object
-      if (el.component.name === "FormText") {
+      if (el.component.name === 'FormText') {
         return {
           validation
         };
@@ -199,24 +199,24 @@ The "field-level" approach allows to you add a `validations` property to your fi
 Here is an example of a schema that uses all the possible `validations` value types:
 
 ```js
-import * as yup from "yup";
+import * as yup from 'yup';
 
 const schema = {
   email: {
     component: FormText,
-    label: "Email",
+    label: 'Email',
     // Globally defined rules
-    validations: "required|email"
+    validations: 'required|email'
   },
   password: {
     component: FormText,
-    label: "Password",
+    label: 'Password',
     // Validation functions
     validations: value => value && value.length > 6
   },
   fullName: {
     component: FormText,
-    label: "Full Name",
+    label: 'Full Name',
     // yup validations
     validations: yup.string().required()
   }
@@ -248,39 +248,39 @@ This example uses `yup` to define validation schemas for your forms.
 </template>
 
 <script>
-  import * as yup from "yup";
+import * as yup from 'yup';
 
-  export default {
-    components: {
-      SchemaFormWithValidation
-    },
-    setup() {
-      const schema = ref([
-        // Fields without the `validation` prop
-      ]);
+export default {
+  components: {
+    SchemaFormWithValidation
+  },
+  setup() {
+    const schema = ref([
+      // Fields without the `validation` prop
+    ]);
 
-      const formData = ref({});
-      useSchemaForm(formData);
+    const formData = ref({});
+    useSchemaForm(formData);
 
-      // The validation schema
-      const validationSchema = yup.object().shape({
-        email: yup
-          .string()
-          .email()
-          .required(),
-        password: yup
-          .string()
-          .min(5)
-          .required(),
-        fullName: yup.string().required()
-      });
+    // The validation schema
+    const validationSchema = yup.object().shape({
+      email: yup
+        .string()
+        .email()
+        .required(),
+      password: yup
+        .string()
+        .min(5)
+        .required(),
+      fullName: yup.string().required()
+    });
 
-      return {
-        schema,
-        validationSchema
-      };
-    }
-  };
+    return {
+      schema,
+      validationSchema
+    };
+  }
+};
 </script>
 ```
 
@@ -316,26 +316,26 @@ You can provide initial validation state to the `SchemaForm`, to set initial err
 </template>
 
 <script>
-  export default {
-    setup() {
-      const schema = ref([
-        // schema...
-      ]);
+export default {
+  setup() {
+    const schema = ref([
+      // schema...
+    ]);
 
-      const formData = ref({});
-      useSchemaForm(formData);
+    const formData = ref({});
+    useSchemaForm(formData);
 
-      const initialErrors = {
-        email: "This email is already taken",
-        password: "Password must be at least 8 characters long"
-      };
+    const initialErrors = {
+      email: 'This email is already taken',
+      password: 'Password must be at least 8 characters long'
+    };
 
-      return {
-        schema,
-        initialErrors
-      };
-    }
-  };
+    return {
+      schema,
+      initialErrors
+    };
+  }
+};
 </script>
 ```
 
@@ -353,28 +353,28 @@ You can provide `initial-touched` prop to set the initial `touched` meta flags f
 </template>
 
 <script>
-  export default {
-    setup() {
-      const schema = ref([
-        // schema...
-      ]);
+export default {
+  setup() {
+    const schema = ref([
+      // schema...
+    ]);
 
-      const formData = ref({});
-      useSchemaForm(formData);
+    const formData = ref({});
+    useSchemaForm(formData);
 
-      const initialTouched = {
-        email: true,
-        password: false
-      };
+    const initialTouched = {
+      email: true,
+      password: false
+    };
 
-      return {
-        formData,
-        schema,
-        initialErrors,
-        initialTouched
-      };
-    }
-  };
+    return {
+      formData,
+      schema,
+      initialErrors,
+      initialTouched
+    };
+  }
+};
 </script>
 ```
 
@@ -411,7 +411,7 @@ The following are a few common examples for behaviors implemented with the form-
 ```html
 <SchemaForm :schema="schema">
   <template #afterForm="{ validation }">
-    <button :disabled="!validation.meta.valid">Submit</button>
+    <button :aria-disabled="!validation.meta.valid">Submit</button>
   </template>
 </SchemaForm>
 ```

--- a/docs/3.x/src/guide/veevalidate.md
+++ b/docs/3.x/src/guide/veevalidate.md
@@ -403,3 +403,38 @@ The form-level `validation` object contains the following properties:
   </SchemaForm>
 </template>
 ```
+
+The following are a few common examples for behaviors implemented with the form-level validation state.
+
+**Disable buttons until all fields are valid**
+
+```html
+<SchemaForm :schema="schema">
+  <template #afterForm="{ validation }">
+    <button :disabled="!validation.meta.valid">Submit</button>
+  </template>
+</SchemaForm>
+```
+
+**Display spinner or loading state when the form is submitting**
+
+```vue
+<SchemaForm :schema="schema">
+  <template #afterForm="{ validation }">
+    <button :class="{ 'is-submitting': validation.isSubmitting }">Submit</button>
+  </template>
+</SchemaForm>
+```
+
+**Display all errors as a summary before the form fields**
+
+```html
+<SchemaForm :schema="schema">
+  <template #beforeForm="{ validation }">
+    <p>Please correct these errors</p>
+    <ul v-if="validation.errors">
+      <li v-for="error in validation.errors">{{ error }}</li>
+    </ul>
+  </template>
+</SchemaForm>
+```

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -6,6 +6,7 @@
     <slot
       v-if="behaveLikeParentSchema"
       name="beforeForm"
+      v-bind="slotBinds"
     />
 
     <div
@@ -25,6 +26,7 @@
     <slot
       v-if="behaveLikeParentSchema"
       name="afterForm"
+      v-bind="slotBinds"
     />
   </component>
 </template>
@@ -89,11 +91,16 @@ export default {
       }
     })
 
+    const slotBinds = computed(() => {
+      return {}
+    })
+
     return {
       behaveLikeParentSchema,
       parsedSchema,
       hasParentSchema,
-      formBinds
+      formBinds,
+      slotBinds
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR is a draft implementation for the [slot binds proposal](https://github.com/formvuelate/formvuelate/discussions/180), by exposing a `slotBinds` computed property on the base schema. Plugins will be able to override it and expose their own state which is then available to consumers on `afterForm` and `beforeForm` slots.

An example implementation for the vee-validate plugin can be [found here](https://github.com/formvuelate/formvuelate-plugin-vee-validate/pull/18)

This PR doesn't currently address the need to obtain the plugin state in the `script` block, which will probably require some composition API magic, I'm not yet sure if it should be in the scope of this PR or not.