### PR TITLE
chore: generate TypeScript declarations for plugins

### DIFF
--- a/packages/plugin-lookup/package.json
+++ b/packages/plugin-lookup/package.json
@@ -36,5 +36,6 @@
   "homepage": "https://github.com/formvuelate/formvuelate-plugin-lookup#readme",
   "module": "dist/formvuelate-plugin-lookup.es.js",
   "unpkg": "dist/formvuelate-plugin-lookup.umd.js",
-  "browser": "dist/formvuelate-plugin-lookup.es.js"
+  "browser": "dist/formvuelate-plugin-lookup.es.js",
+  "types": "dist/formvuelate-plugin-lookup.d.ts.js"
 }

--- a/packages/plugin-lookup/src/types/index.d.ts
+++ b/packages/plugin-lookup/src/types/index.d.ts
@@ -1,0 +1,11 @@
+import { PluginFunction } from 'formvuelate'
+
+interface PluginOptions {
+  mapComponents: Record<string, string>;
+  mapProps: Record<string, any>;
+  preserveMappedProps: boolean;
+}
+
+declare const LookupPlugin: (opts?: Partial<PluginOptions>) => PluginFunction
+
+export default LookupPlugin

--- a/packages/plugin-vee-validate/package.json
+++ b/packages/plugin-vee-validate/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.2",
   "description": "FormVueLate Vee-validate plugin",
   "main": "dist/formvuelate-plugin-vee-validate.cjs.js",
+  "types": "dist/formvuelate-plugin-vee-validate.d.ts",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-vee-validate/src/types/index.d.ts
+++ b/packages/plugin-vee-validate/src/types/index.d.ts
@@ -1,0 +1,22 @@
+import { PluginFunction } from 'formvuelate'
+
+interface ValidationProps {
+  errorMessage?: string;
+  errors: string[];
+  meta: {
+    valid: boolean;
+    dirty: boolean;
+    touched: boolean;
+    pending: boolean;
+    initialValue: any;
+  },
+  setTouched(touched: boolean): void;
+}
+
+interface PluginOptions {
+  mapProps: (validation: ValidationProps) => Record<string, any>;
+}
+
+declare const VeeValidatePlugin: (opts?: Partial<PluginOptions>) => PluginFunction
+
+export default VeeValidatePlugin

--- a/scripts/generate-dts.js
+++ b/scripts/generate-dts.js
@@ -15,12 +15,13 @@ function generateDts (pkg) {
     return
   }
 
-  const name = pkgNameMap[pkg]
+  const namespace = require(path.resolve(__dirname, `../packages/${pkg}/package.json`)).name
+  const fileName = pkgNameMap[pkg]
 
   dts.bundle({
-    name,
+    name: namespace,
     main: entry,
-    out: path.resolve(__dirname, `../packages/${pkg}/dist/${name}.d.ts`),
+    out: path.resolve(__dirname, `../packages/${pkg}/dist/${fileName}.d.ts`),
     indent: '  '
   })
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [x] Other, please describe: **TypeScript definitions for plugin packages**

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**


This PR includes the changes in https://github.com/formvuelate/formvuelate-plugin-vee-validate/pull/22 

Also includes typescript definitions for the lookup plugin