### PR TITLE
feat #208: hide row when no visible elements

### DIFF
--- a/packages/formvuelate/src/SchemaForm.vue
+++ b/packages/formvuelate/src/SchemaForm.vue
@@ -9,20 +9,14 @@
       v-bind="slotBinds"
     />
 
-    <div
-      :class="['schema-row', schemaRowClasses]"
-      v-for="(fields, index) in parsedSchema"
+    <SchemaRow
+      v-for="(row, index) in parsedSchema"
       :key="index"
-    >
-      <SchemaField
-        v-for="field in fields"
-        :key="field.model"
-        :field="field"
-        :sharedConfig="sharedConfig"
-        :preventModelCleanupOnSchemaChange="preventModelCleanupOnSchemaChange"
-        class="schema-col"
-      />
-    </div>
+      :row="row"
+      :schemaRowClasses="schemaRowClasses"
+      :sharedConfig="sharedConfig"
+      :preventModelCleanupOnSchemaChange="preventModelCleanupOnSchemaChange"
+    />
 
     <slot
       v-if="behaveLikeParentSchema"
@@ -34,7 +28,7 @@
 
 <script>
 import useParsedSchema from './features/ParsedSchema'
-import SchemaField from './SchemaField.vue'
+import SchemaRow from './SchemaRow.vue'
 
 import { computed } from 'vue'
 
@@ -44,7 +38,7 @@ import useFormModel from './features/FormModel'
 
 export default {
   name: 'SchemaForm',
-  components: { SchemaField },
+  components: { SchemaRow },
   props: {
     schema: {
       type: [Object, Array],

--- a/packages/formvuelate/src/SchemaRow.vue
+++ b/packages/formvuelate/src/SchemaRow.vue
@@ -1,0 +1,57 @@
+<template>
+  <div
+    v-if="rowHasVisibleElements"
+    :class="['schema-row', schemaRowClasses]"
+  >
+    <SchemaField
+      v-for="field in row"
+      :key="field.model"
+      :field="field"
+      v-bind="$attrs"
+      class="schema-col"
+    />
+  </div>
+</template>
+
+<script>
+import SchemaField from './SchemaField.vue'
+
+import { computed, inject } from 'vue'
+import { FORM_MODEL } from './utils/constants'
+
+export default {
+  name: 'SchemaRow',
+  components: { SchemaField },
+
+  props: {
+    row: {
+      type: Array,
+      required: true
+    },
+    schemaRowClasses: {
+      type: [String, Object, Array],
+      default: null
+    }
+  },
+
+  setup (props) {
+    const formModel = inject(FORM_MODEL, {})
+
+    const rowHasVisibleElements = computed(() => {
+      for (const field of props.row) {
+        // If a field doesnt have a condition it guarantees itll be rendered
+        if (!field.condition) return true
+
+        // If a field condition is true, it will be rendered
+        if (typeof condition !== 'function' && field.condition(formModel.value) === true) return true
+      }
+
+      return false
+    })
+
+    return {
+      rowHasVisibleElements
+    }
+  }
+}
+</script>

--- a/packages/formvuelate/tests/unit/SchemaRow.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaRow.spec.js
@@ -1,0 +1,58 @@
+import SchemaRow from '../../src/SchemaRow.vue'
+import SchemaField from '../../src/SchemaField.vue'
+
+import { shallowMount } from '@vue/test-utils'
+
+const FormText = {
+  template: '<input/>',
+  props: ['label'],
+  emits: ['update:modelValue']
+}
+
+describe('SchemaRow', () => {
+  it('doesnt render if the containing elements are not showing', () => {
+    const wrapper = shallowMount(SchemaRow, {
+      props: {
+        row: [
+          {
+            model: 'FirstName',
+            component: FormText,
+            label: 'First Name',
+            condition: model => false
+          },
+          {
+            model: 'LastName',
+            component: FormText,
+            label: 'Last Name',
+            condition: model => false
+          }
+        ]
+      }
+    })
+
+    expect(wrapper.element.tagName).toBeUndefined()
+  })
+
+  it('renders if at least one of the conditions is true', () => {
+    const wrapper = shallowMount(SchemaRow, {
+      props: {
+        row: [
+          {
+            model: 'FirstName',
+            component: FormText,
+            label: 'First Name',
+            condition: model => false
+          },
+          {
+            model: 'LastName',
+            component: FormText,
+            label: 'Last Name',
+            condition: model => true
+          }
+        ]
+      }
+    })
+
+    expect(wrapper.findAllComponents(SchemaField).length).toBe(2)
+  })
+})


### PR DESCRIPTION
If no elements in the row are visible due to conditions being false, the row will not render an empty div.
Additionally refactors the logic into a SchemaRow intermediate component, this was needed due to not being able to modify the loop. The `parsedSchema` computed MUST be used or else a refactor of the plugins would be required, so the logic had to be enclosed into a new component.

closes: #208

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
