### PR TITLE
feat: allow plugins to extend form props

### DIFF
--- a/packages/formvuelate/src/SchemaFormFactory.js
+++ b/packages/formvuelate/src/SchemaFormFactory.js
@@ -22,6 +22,18 @@ export default function SchemaFormFactory (plugins = [], components = null) {
     }
   }
 
+  const formProps = { ...SchemaForm.props }
+
+  function extendProps (newProps = {}) {
+    Object.assign(formProps, newProps || {})
+  }
+
+  plugins.forEach(plugin => {
+    if (plugin.beforeSetup) {
+      plugin.beforeSetup({ extendProps })
+    }
+  })
+
   const SchemaFieldWithComponents = {
     ...SchemaField,
     components: {
@@ -32,6 +44,7 @@ export default function SchemaFormFactory (plugins = [], components = null) {
 
   return {
     ...SchemaForm,
+    props: formProps,
     components: {
       ...components,
       ...SchemaForm.components,

--- a/packages/formvuelate/src/SchemaFormFactory.js
+++ b/packages/formvuelate/src/SchemaFormFactory.js
@@ -8,10 +8,10 @@ export default function SchemaFormFactory (plugins = [], components = null) {
 
   const schemaFormProps = { ...SchemaForm.props }
 
-  function extendProps (newProps) {
+  function extendSchemaFormProps (newProps) {
     if (!isObject(newProps)) {
       if (process.env && process.env.NODE_ENV !== 'production') {
-        console.warn('Formvuelate: extendProps can only receive a Vue props object')
+        console.warn('Formvuelate: extendSchemaFormProps can only receive a Vue props object')
       }
       return
     }
@@ -20,8 +20,8 @@ export default function SchemaFormFactory (plugins = [], components = null) {
   }
 
   plugins.forEach(plugin => {
-    if (plugin.beforeSetup) {
-      plugin.beforeSetup({ extendProps })
+    if (plugin.extend) {
+      plugin.extend({ extendSchemaFormProps })
     }
   })
 

--- a/packages/formvuelate/src/SchemaFormFactory.js
+++ b/packages/formvuelate/src/SchemaFormFactory.js
@@ -11,7 +11,7 @@ export default function SchemaFormFactory (plugins = [], components = null) {
   function extendSchemaFormProps (newProps) {
     if (!isObject(newProps)) {
       if (process.env && process.env.NODE_ENV !== 'production') {
-        console.warn('Formvuelate: extendSchemaFormProps can only receive a Vue props object')
+        console.warn('FormVueLate: extendSchemaFormProps can only receive a Vue props object')
       }
       return
     }

--- a/packages/formvuelate/src/features/DefinePlugin.js
+++ b/packages/formvuelate/src/features/DefinePlugin.js
@@ -1,0 +1,18 @@
+/**
+ * A helper function to make creating plugins easier
+ * @param plugin The plugin function or object
+ */
+export default function definePlugin (plugin) {
+  // function plugin
+  if (typeof plugin === 'function') {
+    return plugin
+  }
+
+  // plugin with advanced options
+  const pluginFn = plugin.setup
+  if ('extend' in plugin) {
+    pluginFn.extend = plugin.extend
+  }
+
+  return pluginFn
+}

--- a/packages/formvuelate/src/index.js
+++ b/packages/formvuelate/src/index.js
@@ -2,6 +2,7 @@ import SchemaForm from './SchemaForm.vue'
 import SchemaWizard from './SchemaWizard.vue'
 import SchemaFormFactory from './SchemaFormFactory'
 import useSchemaForm from './features/useSchemaForm'
+import definePlugin from './features/DefinePlugin'
 import * as constants from './utils/constants'
 
 export default SchemaForm
@@ -11,5 +12,6 @@ export {
   SchemaWizard,
   SchemaFormFactory,
   useSchemaForm,
+  definePlugin,
   constants
 }

--- a/packages/formvuelate/src/types/index.d.ts
+++ b/packages/formvuelate/src/types/index.d.ts
@@ -12,6 +12,12 @@ export type FormArraySchema = FieldSchemaWithModel[];
 
 export type FormObjectSchema = Record<string, FieldSchema>;
 
+interface PluginExtensionFunctions {
+  extendFormProps(extendedProps: Record<string, any>): void;
+}
+
+export type PluginExtenderFunction = (extensions: PluginExtensionFunctions) => unknown;
+
 export interface BaseSchemaReturns {
   behaveLikeParentSchema: ComputedRef<boolean>;
   parsedSchema: ComputedRef<FormArraySchema[]>;
@@ -24,9 +30,9 @@ export declare function useSchemaForm<
   TValues extends Record<string, any> = Record<string, any>
 >(initialFormValues?: TValues): { formModel: TValues };
 
-export type PluginFunction = (
+export type PluginFunction = { extend?: PluginExtenderFunction } & ((
   baseReturns: BaseSchemaReturns
-) => BaseSchemaReturns;
+) => BaseSchemaReturns);
 
 export declare function SchemaFormFactory(
   plugins?: PluginFunction[],
@@ -83,3 +89,5 @@ declare const SchemaWizard: DefineComponent<{
   };
 }> &
   FormSlots
+
+export declare function definePlugin(plugin: PluginFunction | { setup: PluginFunction, extend: PluginExtenderFunction }): PluginFunction;

--- a/packages/formvuelate/src/utils/assertions.js
+++ b/packages/formvuelate/src/utils/assertions.js
@@ -1,0 +1,8 @@
+/**
+ * Returns true if the passed value is an object
+ * @param {*} obj
+ * @returns {boolean}
+ */
+export function isObject (obj) {
+  return obj !== null && !!obj && typeof obj === 'object' && !Array.isArray(obj)
+}

--- a/packages/plugin-vee-validate/src/index.js
+++ b/packages/plugin-vee-validate/src/index.js
@@ -1,5 +1,6 @@
 import { toRefs, h, computed, markRaw, watch, getCurrentInstance, unref, resolveDynamicComponent, inject, provide } from 'vue'
 import { useForm, useField } from 'vee-validate'
+import { definePlugin } from 'formvuelate'
 
 /**
  * For a Schema, find the elements in each of the rows and remap the element with the given function
@@ -120,8 +121,9 @@ export default function VeeValidatePlugin (opts) {
     }
   }
 
-  veeValidatePlugin.beforeSetup = ({ extendProps }) => {
-    extendProps({
+  // extends the schema form props
+  const extend = ({ extendSchemaFormProps }) => {
+    extendSchemaFormProps({
       validationSchema: {
         type: null,
         default: undefined
@@ -129,7 +131,10 @@ export default function VeeValidatePlugin (opts) {
     })
   }
 
-  return veeValidatePlugin
+  return definePlugin({
+    setup: veeValidatePlugin,
+    extend
+  })
 }
 
 // Used to track if a component was already marked

--- a/packages/plugin-vee-validate/src/index.js
+++ b/packages/plugin-vee-validate/src/index.js
@@ -125,7 +125,7 @@ export default function VeeValidatePlugin (opts) {
   const extend = ({ extendSchemaFormProps }) => {
     extendSchemaFormProps({
       validationSchema: {
-        type: null,
+        type: Object,
         default: undefined
       }
     })

--- a/packages/plugin-vee-validate/src/index.js
+++ b/packages/plugin-vee-validate/src/index.js
@@ -25,8 +25,8 @@ export default function VeeValidatePlugin (opts) {
   // Maps the validation state exposed by vee-validate to components
   const mapProps = (opts && opts.mapProps) || defaultMapProps
 
-  return function veeValidatePlugin (baseReturns) {
-  // Take the parsed schema from SchemaForm setup returns
+  function veeValidatePlugin (baseReturns, props) {
+    // Take the parsed schema from SchemaForm setup returns
     const { parsedSchema, formBinds } = baseReturns
 
     // Get additional properties not defined on the `SchemaForm` derivatives
@@ -36,7 +36,7 @@ export default function VeeValidatePlugin (opts) {
     if (!formContext) {
       // if non-existent create one and provide it for nested schemas
       formContext = useForm({
-        validationSchema: formAttrs['validation-schema'] || formAttrs.validationSchema,
+        validationSchema: props.validationSchema ? computed(() => props.validationSchema) : undefined,
         initialErrors: formAttrs['initial-errors'] || formAttrs.initialErrors,
         initialTouched: formAttrs['initial-touched'] || formAttrs.initialTouched
       })
@@ -119,6 +119,17 @@ export default function VeeValidatePlugin (opts) {
       parsedSchema: formSchemaWithVeeValidate
     }
   }
+
+  veeValidatePlugin.beforeSetup = ({ extendProps }) => {
+    extendProps({
+      validationSchema: {
+        type: null,
+        default: undefined
+      }
+    })
+  }
+
+  return veeValidatePlugin
 }
 
 // Used to track if a component was already marked


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR allows plugin to extend the `SchemaForm` props by introducing a `beforeSetup` (name not final) cycle which allows plugins to do stuff before the setup function is called.

The `beforeSetup` passes a context object that contains various utilities to allow plugins to extend the `SchemaForm` component definition, at the moment I think by using small functions like `extendProps` we can control the level of access plugins have.

Still thinking about the API, so any pointers are appreciated, this just a first stab at it.

closes https://github.com/formvuelate/formvuelate-plugin-vee-validate/issues/19