### PR TITLE
feat: lookup plugin replace SchemaForm with plugin version in sub schemas closes #224

### DIFF
--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -27,6 +27,10 @@ jobs:
       run: yarn
     - name: Lint
       run: yarn ci:lint
+    - name: Build
+      run: yarn build
+    - name: Link cross dependencies
+      run: yarn lerna bootstrap
     - name: Test units
       run: yarn test:unit
     - name: Codecov

--- a/cypress.json
+++ b/cypress.json
@@ -2,7 +2,7 @@
   "pluginsFile": "packages/formvuelate/tests/e2e/plugins/index.js",
   "supportFile": "packages/formvuelate/tests/e2e/support/index.js",
   "component": {
-    "componentFolder": "packages/formvuelate/src",
+    "componentFolder": "packages/formvuelate/tests/e2e/specs",
     "testFiles": "**/*.e2e.js"
   }
 }

--- a/docs/3.x/src/guide/lookup.md
+++ b/docs/3.x/src/guide/lookup.md
@@ -309,6 +309,7 @@ The schema will now include both the mapped `component` property, plus the origi
 
 ## Nested Schema Caveats
 
+### lookupSubSchemas <Badge text="3.6.0" type="warning" vertical="middle" />
 When dealing with schemas that have sub-schemas like the following:
 
 ```json
@@ -321,15 +322,15 @@ When dealing with schemas that have sub-schemas like the following:
     "component": "SchemaForm",
     "schema": {
       "address": {
-        "type": "FormText",
+        "type": "string",
         "label": "Work address"
       },
       "details": {
         "component": "SchemaForm",
         "schema": {
           "position": {
-            "type": "FormText",
-            "label": "Work position"
+            "type": "string",
+            "label": "Work email"
           }
         }
       }
@@ -338,16 +339,39 @@ When dealing with schemas that have sub-schemas like the following:
 }
 ```
 
-Make sure that you use `mapComponents` to change `SchemaForm` for whatever you named the output of your `SchemaFormFactory` function call.
+We have to do a little extra work to allow the lookup plugin to remap the sub-schema `SchemaForm` components.
+
+First, import the `lookupSubSchemas` composition function from the `plugin-lookup` package.
 
 ```js
-// Note "SchemaFormWithPlugin" getting remapped
+import LookupPlugin, { lookupSubSchemas } from '@formvuelate/plugin-lookup'
+```
 
-const SchemaFormWithPlugin = SchemaFormFactory([
+Next, create your schema form with plugins as you normally would.
+
+```js
+const SchemaFormWithPlugins = SchemaFormFactory([
   LookupPlugin({
-      SchemaForm: 'SchemaFormWithPlugin',
-      [...]
+    mapComponents: {
+      Text: BaseInput
     }
   })
 ])
+```
+
+Finally, in your setup function and _before_ the `useSchemaForm` call, call the `lookupSubSchemas` function that we just imported and pass in as a parameter the plugin-enhanced `SchemaForm` component returned by `SchemaFormFactory`.
+
+```js
+setup () {
+  const model = ref({})
+
+  lookupSubSchemas(SchemaFormWithPlugins)
+  useSchemaForm(model)
+
+  const schema = shallowRef(MY_SCHEMA)
+
+  return {
+    schema
+  }
+}
 ```

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e:ci": "cypress run-ct",
     "lint": "eslint . '**/*.{js,jsx,ts,tsx}' --fix",
     "ci:lint": "yarn lint --no-fix",
-    "test": "yarn lint && yarn test:unit",
+    "test": "yarn lint && yarn test:unit && yarn test:e2e:ci",
     "test:unit:watch": "yarn test:unit --watch",
     "docs:dev": "cd docs/3.x && yarn dev && cd -",
     "docs:build": "cd docs/3.x && yarn build && cd -",

--- a/packages/formvuelate/src/features/ParsedSchema.js
+++ b/packages/formvuelate/src/features/ParsedSchema.js
@@ -104,8 +104,6 @@ export default function useParsedSchema (refSchema, model) {
           (field.component.name === 'SchemaForm' || field.component === 'SchemaForm')
         ) {
           fieldCopy.component = injectedLookupSchemaForm
-
-          console.log(fieldCopy)
         }
 
         return {

--- a/packages/formvuelate/src/features/ParsedSchema.js
+++ b/packages/formvuelate/src/features/ParsedSchema.js
@@ -1,4 +1,5 @@
-import { computed, unref } from 'vue'
+import { computed, inject, unref } from 'vue'
+import { LOOKUP_PARSE_SUB_SCHEMA_FORMS } from '../utils/constants'
 import useUniqueID from './UniqueID'
 
 /**
@@ -89,11 +90,29 @@ export default function useParsedSchema (refSchema, model) {
       }
     }
 
+    const injectedLookupSchemaForm = inject(LOOKUP_PARSE_SUB_SCHEMA_FORMS, null)
+
     return normalizedSchema.map(fieldGroup => {
-      return fieldGroup.map(field => ({
-        ...field,
-        uuid: getID(field.model)
-      }))
+      return fieldGroup.map(field => {
+        const fieldCopy = { ...field }
+
+        /**
+         * If LookupPlugin has injected a plugin-enhanced version of SchemaForm
+         * through `lookupSubSchemas` function, replace the regular `SchemaForm` with it
+         */
+        if (injectedLookupSchemaForm &&
+          (field.component.name === 'SchemaForm' || field.component === 'SchemaForm')
+        ) {
+          fieldCopy.component = injectedLookupSchemaForm
+
+          console.log(fieldCopy)
+        }
+
+        return {
+          ...fieldCopy,
+          uuid: getID(field.model)
+        }
+      })
     })
   })
 

--- a/packages/formvuelate/src/utils/constants.js
+++ b/packages/formvuelate/src/utils/constants.js
@@ -15,3 +15,5 @@ export const FIND_NESTED_FORM_MODEL_PROP = `${KEY}findNestedFormModelProp`
 export const UPDATE_FORM_MODEL = `${KEY}updateFormModel`
 
 export const DELETE_FORM_MODEL_PROP = `${KEY}deleteFormModelProp`
+
+export const LOOKUP_PARSE_SUB_SCHEMA_FORMS = `${KEY}parseSubSchemaForms`

--- a/packages/formvuelate/tests/e2e/specs/SchemaForm.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaForm.e2e.js
@@ -1,8 +1,9 @@
 import { mount } from '@cypress/vue'
-import SchemaForm from './SchemaForm.vue'
+import SchemaForm from '../../../src/SchemaForm.vue'
 
-import useSchemaForm from './features/useSchemaForm'
+import useSchemaForm from '../../../src/features/useSchemaForm'
 import { shallowRef, ref, h, computed } from 'vue'
+import { BaseInput } from '../../utils/components'
 
 const SchemaFormWrapper = (schema) => ({
   components: [SchemaForm],
@@ -23,20 +24,6 @@ const SchemaFormWrapper = (schema) => ({
     })
   }
 })
-
-const BaseInput = {
-  props: ['label', 'modelValue'],
-  render () {
-    return [
-      h('label', this.label),
-      h('input', {
-        ...this.$attrs,
-        value: this.modelValue,
-        onInput: ($event) => this.$emit('update:modelValue', $event.target.value)
-      })
-    ]
-  }
-}
 
 describe('SchemaForm', () => {
   it('renders elements', () => {

--- a/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
@@ -1,0 +1,73 @@
+import { mount } from '@cypress/vue'
+
+import { h, ref, shallowRef } from 'vue'
+import { SchemaFormFactory, SchemaForm, useSchemaForm } from '../../../src/index'
+import LookupPlugin, { lookupSubSchemas } from '../../../../plugin-lookup/src/index'
+import { BaseInput } from '../../utils/components'
+
+describe('SchemaFormFactory', () => {
+  describe('with lookup plugin', () => {
+    it('parses subschema SchemaForm elements', () => {
+      const SCHEMA = [
+        {
+          model: 'firstName',
+          component: 'Text',
+          label: 'First Name'
+        },
+        {
+          model: 'nested',
+          component: 'SchemaForm',
+          schema: [
+            {
+              model: 'nestedfirstName',
+              component: 'Text',
+              label: 'First Name nested'
+            },
+            {
+              model: 'nestedLastName',
+              component: BaseInput,
+              label: 'Last name nested'
+            },
+            {
+              model: 'doubleNested',
+              component: 'SchemaForm',
+              schema: [
+                {
+                  model: 'doubleNestedName',
+                  component: 'Text',
+                  label: 'Double nested text'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      const SchemaFormWithPlugins = SchemaFormFactory([
+        LookupPlugin({
+          mapComponents: {
+            Text: BaseInput
+          }
+        })
+      ])
+
+      mount({
+        components: { SchemaFormWithPlugins },
+        setup () {
+          const model = ref({})
+          lookupSubSchemas(SchemaFormWithPlugins)
+          useSchemaForm(model)
+
+          const schemaRef = shallowRef(SCHEMA)
+
+          return () => h(SchemaFormWithPlugins, {
+            schema: schemaRef
+          })
+        }
+      })
+
+      cy.get('input').should('have.length', 4)
+      cy.get('label').eq(3).should('have.text', 'Double nested text')
+    })
+  })
+})

--- a/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
@@ -1,7 +1,7 @@
 import { mount } from '@cypress/vue'
 
 import { h, ref, shallowRef } from 'vue'
-import { SchemaFormFactory, SchemaForm, useSchemaForm } from '../../../src/index'
+import { SchemaFormFactory, useSchemaForm } from '../../../src/index'
 import LookupPlugin, { lookupSubSchemas } from '../../../../plugin-lookup/src/index'
 import { BaseInput } from '../../utils/components'
 

--- a/packages/formvuelate/tests/utils/components.js
+++ b/packages/formvuelate/tests/utils/components.js
@@ -1,0 +1,15 @@
+import { h } from 'vue'
+
+export const BaseInput = {
+  props: ['label', 'modelValue'],
+  render () {
+    return [
+      h('label', this.label),
+      h('input', {
+        ...this.$attrs,
+        value: this.modelValue,
+        onInput: ($event) => this.$emit('update:modelValue', $event.target.value)
+      })
+    ]
+  }
+}

--- a/packages/plugin-lookup/src/index.js
+++ b/packages/plugin-lookup/src/index.js
@@ -1,4 +1,14 @@
-import { computed } from 'vue'
+import { computed, provide } from 'vue'
+import { constants } from 'formvuelate'
+
+/**
+ * Signal ParsedSchema to replace all instances of subschema `SchemaForm` components
+ * with the SchemaFormWithPlugins component
+ * @param {Object} SchemaFormWithPlugins
+ */
+export const lookupSubSchemas = (SchemaFormWithPlugins) => {
+  provide(constants.LOOKUP_PARSE_SUB_SCHEMA_FORMS, SchemaFormWithPlugins)
+}
 
 /**
  * LookupPlugin
@@ -50,6 +60,7 @@ const mapComps = (schema, mapComponents) => {
   return mapElementsInSchema(schema, el => {
     const newKey = mapComponents[el.component]
 
+    if (el.schema) return { ...el }
     if (!newKey) return { ...el }
 
     return {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The change on the lookup plugin requires a new exported constant on the main `formvuelate` library, so until we publish everything please run `yarn build` locally to update the import reference to `import { constants } from 'formvuelate'
` inside `index.js` in lookup.

Afterwards, can run `yarn test:e2e` to run the new SchemaFormFactory e2e which covers the scenario

This PR will effectively "tie" the two together through the constant, but I don't feel like this is a major issue and keeps the code as clean/readable as possible without having to resort to magic hacks.

The proposed API would be:

```js
import LookupPlugin, { lookupSubSchemas } from '@formvuelate/plugin-looup'

// With the following schema
const SCHEMA = [
        {
          model: 'firstName',
          component: 'Text',
          label: 'First Name'
        },
        {
          model: 'nested',
          component: 'SchemaForm', // Notice string versions of schema form here
          schema: [
            {
              model: 'nestedfirstName',
              component: 'Text', // This would not normally works since its a subschema
              label: 'First Name nested'
            },
            {
              model: 'nestedLastName',
              component: BaseInput,
              label: 'Last name nested'
            },
            {
              model: 'doubleNested',
              component: 'SchemaForm',
              schema: [
                {
                  model: 'doubleNestedName',
                  component: 'Text',
                  label: 'Double nested text'
                }
              ]
            }
          ]
        }
      ]

const SchemaFormWithPlugins = SchemaFormFactory([
      LookupPlugin({
        mapComponents: {
          Text: BaseInput // no longer needing to parse SchemaForm, it didn't work anyway
        }
      })
    ])

      setup () {
        const model = ref({})

        // this new import from LookupPlugin would allow to tell formvuelate to replace sub schema components
        lookupSubSchemas(SchemaFormWithPlugins)
        useSchemaForm(model)

        const schemaRef = shallowRef(SCHEMA)

       return {
         schema: schemaRef
      }
      }
```
