### PR TITLE
fix: deep map schema fields against lookup components fixes #224

### DIFF
--- a/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
@@ -3,6 +3,7 @@ import { mount } from '@cypress/vue'
 import { h, ref, shallowRef } from 'vue'
 import { SchemaFormFactory, useSchemaForm } from '../../../src/index'
 import LookupPlugin, { lookupSubSchemas } from '../../../../plugin-lookup/src/index'
+import VeeValidatePlugin from '../../../../plugin-vee-validate/src/index'
 import { BaseInput } from '../../utils/components'
 
 describe('SchemaFormFactory', () => {
@@ -68,6 +69,62 @@ describe('SchemaFormFactory', () => {
 
       cy.get('input').should('have.length', 4)
       cy.get('label').eq(3).should('have.text', 'Double nested text')
+    })
+  })
+
+  describe('with lookup and vee-validate', () => {
+    it('integrates lookup and vee plugins in nested schemas', () => {
+      const SCHEMA = [
+        {
+          model: 'firstName',
+          component: 'Text',
+          label: 'First Name'
+        },
+        {
+          model: 'nested',
+          component: 'SchemaForm',
+          schema: [
+            {
+              model: 'nestedfirstName',
+              component: 'Text',
+              label: 'First Name nested',
+              validations: value => value && value.length > 3
+            }
+          ]
+        }
+      ]
+
+      const SchemaFormWithPlugins = SchemaFormFactory([
+        LookupPlugin({
+          mapComponents: {
+            Text: BaseInput
+          }
+        }),
+        VeeValidatePlugin({})
+      ])
+
+      mount({
+        components: { SchemaFormWithPlugins },
+        setup () {
+          const model = ref({})
+          lookupSubSchemas(SchemaFormWithPlugins)
+          useSchemaForm(model)
+
+          const schemaRef = shallowRef(SCHEMA)
+
+          return () => h(SchemaFormWithPlugins, {
+            schema: schemaRef
+          })
+        }
+      })
+
+      cy.get('input').should('have.length', 2)
+      cy.get('label').eq(1).should('have.text', 'First Name nested')
+
+      cy.get('input').eq(1).type('Ma')
+      cy.get('.error').should('have.text', 'First Name nested is not valid.')
+
+      cy.get('input').eq(1).type('rina')
     })
   })
 })

--- a/packages/formvuelate/tests/utils/components.js
+++ b/packages/formvuelate/tests/utils/components.js
@@ -1,7 +1,7 @@
 import { h } from 'vue'
 
 export const BaseInput = {
-  props: ['label', 'modelValue'],
+  props: ['label', 'modelValue', 'validation'],
   render () {
     return [
       h('label', this.label),
@@ -9,7 +9,15 @@ export const BaseInput = {
         ...this.$attrs,
         value: this.modelValue,
         onInput: ($event) => this.$emit('update:modelValue', $event.target.value)
-      })
+      }),
+      this.$props.validation?.errorMessage
+        ? h('div',
+          {
+            class: 'error'
+          },
+          this.$props.validation.errorMessage
+        )
+        : null
     ]
   }
 }

--- a/packages/plugin-lookup/src/index.js
+++ b/packages/plugin-lookup/src/index.js
@@ -57,17 +57,36 @@ export const mapElementsInSchema = (schema, fn) => schema.map(row => row.map(el 
 * @returns {Array}
  */
 const mapComps = (schema, mapComponents) => {
-  return mapElementsInSchema(schema, el => {
+  function mapSchemaElement (el) {
     const newKey = mapComponents[el.component]
 
-    if (el.schema) return { ...el }
+    // recursively exhaust all sub schemas
+    if (el.schema) {
+      const schemaArray = Array.isArray(el.schema)
+        ? el.schema
+        : Object.keys(el.schema).map(model => {
+          return {
+            model,
+            ...el.schema[model]
+          }
+        })
+
+      return {
+        ...el,
+        component: mapComponents[el.component] || el.component,
+        schema: schemaArray.map(mapSchemaElement)
+      }
+    }
+
     if (!newKey) return { ...el }
 
     return {
       ...el,
       component: mapComponents[el.component]
     }
-  })
+  }
+
+  return mapElementsInSchema(schema, mapSchemaElement)
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Solves the #224 issue by having the lookup plugin do a deep map using recursion to ensure it converts all fields before passing them along to the next plugin in the list.