### PR TITLE
fix: local component injection refactor fixes #238

### DIFF
--- a/packages/formvuelate/src/SchemaField.vue
+++ b/packages/formvuelate/src/SchemaField.vue
@@ -2,7 +2,7 @@
   <component
     v-if="schemaCondition"
     v-bind="binds"
-    :is="field.component"
+    :is="component"
     :modelValue="fieldValue"
     @update:modelValue="update"
     class="schema-col"
@@ -11,7 +11,7 @@
 
 <script>
 import { inject, computed, watch } from 'vue'
-import { FIND_NESTED_FORM_MODEL_PROP, SCHEMA_MODEL_PATH, FORM_MODEL, UPDATE_FORM_MODEL, DELETE_FORM_MODEL_PROP } from './utils/constants'
+import { FIND_NESTED_FORM_MODEL_PROP, SCHEMA_MODEL_PATH, FORM_MODEL, UPDATE_FORM_MODEL, DELETE_FORM_MODEL_PROP, INJECTED_LOCAL_COMPONENTS } from './utils/constants'
 
 export default {
   name: 'SchemaField',
@@ -66,6 +66,13 @@ export default {
       return condition(formModel.value)
     })
 
+    const component = computed(() => {
+      // Possible local components injected by user from SchemaFormFactory
+      const locals = inject(INJECTED_LOCAL_COMPONENTS, {})
+
+      return locals[props.field.component] || props.field.component
+    })
+
     watch(schemaCondition, shouldDisplay => {
       if (shouldDisplay) return
       if (props.preventModelCleanupOnSchemaChange) return
@@ -77,7 +84,8 @@ export default {
       binds,
       fieldValue,
       update,
-      schemaCondition
+      schemaCondition,
+      component
     }
   }
 }

--- a/packages/formvuelate/src/SchemaFormFactory.js
+++ b/packages/formvuelate/src/SchemaFormFactory.js
@@ -1,6 +1,7 @@
+import { provide, inject } from 'vue'
 import SchemaForm from './SchemaForm.vue'
-import SchemaField from './SchemaField.vue'
 import { isObject } from './utils/assertions'
+import { INJECTED_LOCAL_COMPONENTS } from './utils/constants'
 
 export default function SchemaFormFactory (plugins = [], components = null) {
   // Copy the original SchemaForm setup
@@ -29,10 +30,18 @@ export default function SchemaFormFactory (plugins = [], components = null) {
     // Call the original setup and preserve its results
     const baseSchemaFormReturns = originalSetup(props, context)
 
+    if (components) {
+      // If user defined local components to be used inside the SchemaForm
+      // injected them so that SchemaField can use them if declared
+      if (!inject(INJECTED_LOCAL_COMPONENTS)) {
+        provide(INJECTED_LOCAL_COMPONENTS, components)
+      }
+    }
+
     if (!plugins.length) return baseSchemaFormReturns
     else {
       // Apply plugins on the data returned
-      // by the original Schemaform
+      // by the original SchemaForm
       return plugins.reduce(
         (schemaFormReturns, plugin) => {
           return plugin(schemaFormReturns, props, context)
@@ -42,21 +51,12 @@ export default function SchemaFormFactory (plugins = [], components = null) {
     }
   }
 
-  const SchemaFieldWithComponents = {
-    ...SchemaField,
-    components: {
-      ...components,
-      ...SchemaField.components
-    }
-  }
-
   return {
     ...SchemaForm,
     props: schemaFormProps,
     components: {
       ...components,
-      ...SchemaForm.components,
-      SchemaField: SchemaFieldWithComponents
+      ...SchemaForm.components
     },
     // Return a customized setup function with plugins
     // as the new SchemaForm setup

--- a/packages/formvuelate/src/utils/constants.js
+++ b/packages/formvuelate/src/utils/constants.js
@@ -17,3 +17,5 @@ export const UPDATE_FORM_MODEL = `${KEY}updateFormModel`
 export const DELETE_FORM_MODEL_PROP = `${KEY}deleteFormModelProp`
 
 export const LOOKUP_PARSE_SUB_SCHEMA_FORMS = `${KEY}parseSubSchemaForms`
+
+export const INJECTED_LOCAL_COMPONENTS = `${KEY}injectedLocalComponents`

--- a/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
@@ -7,6 +7,52 @@ import VeeValidatePlugin from '../../../../plugin-vee-validate/src/index'
 import { BaseInput } from '../../utils/components'
 
 describe('SchemaFormFactory', () => {
+  it('works with a blank plugin configuration and locally defined components', () => {
+    const SchemaFormWithPlugins = SchemaFormFactory([], { BaseInput })
+
+    mount({
+      components: { SchemaFormWithPlugins },
+      setup () {
+        const model = ref({
+          name: '',
+          pet: 'something',
+          nested: {
+
+          }
+        })
+
+        lookupSubSchemas(SchemaFormWithPlugins)
+        useSchemaForm(model)
+
+        const schemaRef = shallowRef({
+          name: {
+            component: 'BaseInput',
+            label: 'Your name'
+          },
+          pet: {
+            component: 'BaseInput',
+            label: 'Your pet'
+          },
+          nested: {
+            component: 'SchemaForm',
+            schema: {
+              game: {
+                component: 'BaseInput',
+                label: 'Videogame'
+              }
+            }
+          }
+        })
+
+        return () => h(SchemaFormWithPlugins, {
+          schema: schemaRef
+        })
+      }
+    })
+
+    cy.get('input').should('have.length', 3)
+  })
+
   describe('with lookup plugin', () => {
     it('parses subschema SchemaForm elements', () => {
       const SCHEMA = [

--- a/packages/formvuelate/tests/unit/SchemaField.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaField.spec.js
@@ -1,6 +1,6 @@
 import useSchemaForm from '../../src/features/useSchemaForm'
 import SchemaField from '../../src/SchemaField.vue'
-import { UPDATE_FORM_MODEL, SCHEMA_MODEL_PATH } from '../../src/utils/constants'
+import { UPDATE_FORM_MODEL, SCHEMA_MODEL_PATH, INJECTED_LOCAL_COMPONENTS } from '../../src/utils/constants'
 
 import { mount } from '@vue/test-utils'
 import { ref, provide } from 'vue'
@@ -16,7 +16,11 @@ const updateFormModel = jest.fn()
 const SchemaFieldWrapper = (
   binds,
   formModel = null,
-  { mockUpdate = false, path = '' } = {}
+  {
+    mockUpdate = false,
+    path = '',
+    injectedLocalComponents = null
+  } = {}
 ) => {
   return {
     components: { SchemaField },
@@ -36,6 +40,11 @@ const SchemaFieldWrapper = (
       if (path) {
         // Usually provided by SchemaForm
         provide(SCHEMA_MODEL_PATH, path)
+      }
+
+      if (injectedLocalComponents) {
+        // Usually provided by SchemaFormFactory
+        provide(INJECTED_LOCAL_COMPONENTS, injectedLocalComponents)
       }
 
       return {
@@ -84,6 +93,24 @@ describe('SchemaField', () => {
       'test',
       null
     )
+  })
+
+  it('uses the injected local components if available', () => {
+    const FormText = { name: 'LocalFormText' }
+
+    const wrapper = mount(
+      SchemaFieldWrapper(
+        {
+          field: {
+            model: 'firstName',
+            component: 'FormText'
+          }
+        }, null,
+        { injectedLocalComponents: { FormText } }
+      )
+    )
+
+    expect(wrapper.findComponent({ name: 'LocalFormText' }).exists()).toBe(true)
   })
 
   describe('binding v-model', () => {

--- a/packages/formvuelate/tests/unit/SchemaFormFactory.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaFormFactory.spec.js
@@ -1,5 +1,8 @@
+import { inject, h } from 'vue'
 import SchemaFormFactory from '../../src/SchemaFormFactory'
 import SchemaForm from '../../src/SchemaForm.vue'
+import { INJECTED_LOCAL_COMPONENTS } from '../../src/utils/constants'
+import { mount } from '@vue/test-utils'
 
 const props = {
   schema: {}
@@ -80,5 +83,35 @@ describe('SchemaFormFactory', () => {
     expect(factory.components).toEqual(
       expect.objectContaining({ FormText, FormSelect })
     )
+  })
+
+  it('provides the local components to sub FVL components', () => {
+    const factory = SchemaFormFactory([], {
+      FormText, FormSelect
+    })
+
+    const injecting = {
+      setup () {
+        const locals = inject(INJECTED_LOCAL_COMPONENTS)
+
+        return {
+          locals
+        }
+      }
+    }
+
+    const wrapper = mount({
+      components: { injecting },
+      setup () {
+        factory.setup(props, context)
+
+        return () => h(injecting)
+      }
+    })
+
+    expect(wrapper.findComponent(injecting).vm.locals).toEqual({
+      FormText,
+      FormSelect
+    })
   })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This has been broken probably for a while since we added the SchemaField and SchemaRow, but the Lookup plugin was covering it up. 
The refactoring allows for an easier way to inject the user defined components in the factory, and directly allow the SchemaField which is the one responsible for rendering the component in the end to set itself to anything the user may have defined in the second parameter object.