### PR TITLE
fix: default boolean false is not accepted [fixes #240]

### DIFF
--- a/packages/formvuelate/src/features/FormModel.js
+++ b/packages/formvuelate/src/features/FormModel.js
@@ -14,7 +14,7 @@ export default function useFormModel (props, parsedSchema) {
     const formModel = inject(FORM_MODEL, {})
 
     forEachSchemaElement(parsedSchema, (el, path) => {
-      if (!el.default) return
+      if (!('default' in el)) return
 
       updateFormModel(formModel, el.model, el.default, path)
     })

--- a/packages/formvuelate/tests/unit/SchemaForm.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaForm.spec.js
@@ -159,6 +159,98 @@ describe('SchemaForm', () => {
     })
   })
 
+  describe('default schema values', () => {
+    it('populates the formModel with the schema when created if a default prop exists', () => {
+      const schema = {
+        firstName: {
+          component: FormText,
+          label: 'First Name',
+          default: 'Darth'
+        },
+        lastName: {
+          component: FormText,
+          label: 'Last Name',
+          default: 'Vader'
+        },
+        contact: {
+          component: SchemaForm,
+          schema: {
+            email: {
+              component: FormText,
+              label: 'Email',
+              default: 'darth@deathstarmail.com'
+            },
+            address: {
+              FormText,
+              label: 'Address'
+            },
+            deepNest: {
+              component: SchemaForm,
+              schema: {
+                lightSaber: {
+                  component: FormText,
+                  label: 'Lightsaber',
+                  default: 'Red'
+                }
+              }
+            }
+          }
+        }
+      }
+
+      const formModel = ref({})
+
+      mount(SchemaWrapperFactory(schema, {}, formModel))
+      expect(formModel.value).toEqual({
+        firstName: 'Darth',
+        lastName: 'Vader',
+        contact: {
+          email: 'darth@deathstarmail.com',
+          deepNest: {
+            lightSaber: 'Red'
+          }
+        }
+      })
+    })
+
+    it('can set default schema values to boolean false', () => {
+      const schema = {
+        firstName: {
+          component: FormText,
+          label: 'First Name',
+          default: false
+        },
+        contact: {
+          component: SchemaForm,
+          schema: {
+            deepNest: {
+              component: SchemaForm,
+              schema: {
+                lightSaber: {
+                  component: FormText,
+                  label: 'Lightsaber',
+                  default: false
+                }
+              }
+            }
+          }
+        }
+      }
+
+      const formModel = ref({})
+
+      mount(SchemaWrapperFactory(schema, {}, formModel))
+      expect(formModel.value).toEqual({
+        firstName: false,
+        contact: {
+          deepNest: {
+            lightSaber: false
+          }
+        }
+      })
+    })
+  })
+
   it('renders a form with multiple nested schemas at the same nesting level', () => {
     const nestedSchema = {
       work: {
@@ -204,59 +296,6 @@ describe('SchemaForm', () => {
 
     expect(wrapper.findAllComponents(FormText)).toHaveLength(2)
     expect(wrapper.findAllComponents(FormSelect)).toHaveLength(2)
-  })
-
-  it('populates the formModel with the schema when created if a default prop exists', () => {
-    const schema = {
-      firstName: {
-        component: FormText,
-        label: 'First Name',
-        default: 'Darth'
-      },
-      lastName: {
-        component: FormText,
-        label: 'Last Name',
-        default: 'Vader'
-      },
-      contact: {
-        component: SchemaForm,
-        schema: {
-          email: {
-            component: FormText,
-            label: 'Email',
-            default: 'darth@deathstarmail.com'
-          },
-          address: {
-            FormText,
-            label: 'Address'
-          },
-          deepNest: {
-            component: SchemaForm,
-            schema: {
-              lightSaber: {
-                component: FormText,
-                label: 'Lightsaber',
-                default: 'Red'
-              }
-            }
-          }
-        }
-      }
-    }
-
-    const formModel = ref({})
-
-    mount(SchemaWrapperFactory(schema, {}, formModel))
-    expect(formModel.value).toEqual({
-      firstName: 'Darth',
-      lastName: 'Vader',
-      contact: {
-        email: 'darth@deathstarmail.com',
-        deepNest: {
-          lightSaber: 'Red'
-        }
-      }
-    })
   })
 
   describe('a11y', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Closes #240
Adds the ability to use boolean `false` as a `default` value for model.
Refactors the check from a general falsey to just evaluating if the property exists in the item.