### PR TITLE
fix: default value parallel schemas

### DIFF
--- a/packages/formvuelate/src/utils/Helpers.js
+++ b/packages/formvuelate/src/utils/Helpers.js
@@ -58,7 +58,7 @@ export const forEachSchemaElement = (schema, fn, path = '') => {
 
   for (const row of normalizedSchema) {
     let rowPath = path
-    
+
     for (const el of row) {
       if (el.schema) {
         rowPath = rowPath === '' ? el.model : `${rowPath}.${el.model}`

--- a/packages/formvuelate/src/utils/Helpers.js
+++ b/packages/formvuelate/src/utils/Helpers.js
@@ -58,6 +58,7 @@ export const forEachSchemaElement = (schema, fn, path = '') => {
 
   for (const row of normalizedSchema) {
     let rowPath = path
+    
     for (const el of row) {
       if (el.schema) {
         rowPath = rowPath === '' ? el.model : `${rowPath}.${el.model}`

--- a/packages/formvuelate/src/utils/Helpers.js
+++ b/packages/formvuelate/src/utils/Helpers.js
@@ -57,15 +57,14 @@ export const forEachSchemaElement = (schema, fn, path = '') => {
   const normalizedSchema = normalizeSchema(unref(schema))
 
   for (const row of normalizedSchema) {
+    let rowPath = path
     for (const el of row) {
       if (el.schema) {
-        path = path === '' ? el.model : `${path}.${el.model}`
-
-        forEachSchemaElement(el.schema, fn, path)
-        return
+        rowPath = rowPath === '' ? el.model : `${rowPath}.${el.model}`
+        forEachSchemaElement(el.schema, fn, rowPath)
       }
 
-      fn(el, path)
+      fn(el, rowPath)
     }
   }
 }

--- a/packages/formvuelate/tests/unit/SchemaForm.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaForm.spec.js
@@ -260,7 +260,7 @@ describe('SchemaForm', () => {
             amount: {
               component: FormText,
               label: 'Amount A',
-              default: '0'
+              default: '10'
             }
           }
         },
@@ -270,15 +270,15 @@ describe('SchemaForm', () => {
             amount: {
               component: FormText,
               label: 'Amount B',
-              default: '0'
+              default: '20'
             }
           }
         }
       })
 
       mount(SchemaWrapperFactory(schema, null, formModel))
-      expect(formModel.value.levelOneA.amount).toEqual('0')
-      expect(formModel.value.levelOneB.amount).toEqual('0')
+      expect(formModel.value.levelOneA.amount).toEqual('10')
+      expect(formModel.value.levelOneB.amount).toEqual('20')
     })
   })
 

--- a/packages/formvuelate/tests/unit/SchemaForm.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaForm.spec.js
@@ -249,6 +249,37 @@ describe('SchemaForm', () => {
         }
       })
     })
+
+    it('populates the formModel with defaults on schemas with multiple top levels', async () => {
+      const formModel = ref({ })
+
+      const schema = ref({
+        levelOneA: {
+          component: SchemaForm,
+          schema: {
+            amount: {
+              component: FormText,
+              label: 'Amount A',
+              default: '0'
+            }
+          }
+        },
+        levelOneB: {
+          component: SchemaForm,
+          schema: {
+            amount: {
+              component: FormText,
+              label: 'Amount B',
+              default: '0'
+            }
+          }
+        }
+      })
+
+      mount(SchemaWrapperFactory(schema, null, formModel))
+      expect(formModel.value.levelOneA.amount).toEqual('0')
+      expect(formModel.value.levelOneB.amount).toEqual('0')
+    })
   })
 
   it('renders a form with multiple nested schemas at the same nesting level', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I found this issue when trying to set default values in a schema with multiple top levels, in either object or array notation. 
i.e. 

```
      const schema = ref({
        levelOneA: {
          component: SchemaForm,
          schema: {
            amount: {
              component: FormText,
              label: 'Amount A',
              default: '0'
            }
          }
        },
        levelOneB: {
          component: SchemaForm,
          schema: {
            amount: {
              component: FormText,
              label: 'Amount B',
              default: '0'
            }
          }
        }
      })
```

Only the first subschema was able to populate the form model with the default values. The default values from the second subschema were ignored.

I traced it down to the `forEachSchemaElement`, which was assuming only one top level schema. By removing the early `return`, and keeping `path` local to each row, the helper can now complete the iteration on all top level sub schemas.

This solved my issue and all tests are passing.

I hope this works for you all too!

