### PR TITLE
fix #248

### DIFF
--- a/packages/formvuelate/src/features/ParsedSchema.js
+++ b/packages/formvuelate/src/features/ParsedSchema.js
@@ -72,6 +72,10 @@ export const normalizeSchema = (schema) => {
 
 export default function useParsedSchema (refSchema, model) {
   const { getID } = useUniqueID()
+  const injectedLookupSchemaForm = inject(
+    LOOKUP_PARSE_SUB_SCHEMA_FORMS,
+    null
+  )
 
   const parsedSchema = computed(() => {
     const schema = unref(refSchema)
@@ -89,8 +93,6 @@ export default function useParsedSchema (refSchema, model) {
         normalizedSchema = normalizeSchema(element.schema)
       }
     }
-
-    const injectedLookupSchemaForm = inject(LOOKUP_PARSE_SUB_SCHEMA_FORMS, null)
 
     return normalizedSchema.map(fieldGroup => {
       return fieldGroup.map(field => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Fixes the warning produced in #248 due to `inject()` called inside the `computed` getter function which doesn't work well in dynamic runtime schemas that may change after the initial `setup` is called. 

Note: we still have some tests producing the warning due to the `useParsedSchema` unit tests, but they have nothing to do with this issue.

closes #248