### PR TITLE
fix: no warnings on empty array schemas

### DIFF
--- a/packages/formvuelate/src/SchemaForm.vue
+++ b/packages/formvuelate/src/SchemaForm.vue
@@ -45,6 +45,7 @@ export default {
       required: true,
       validator (schema) {
         if (!Array.isArray(schema)) return true
+        if (schema.length === 0) return true
 
         return schema.filter(field => !Array.isArray(field) && (!field.model && !field.schema)).length === 0
       }

--- a/packages/formvuelate/tests/unit/SchemaForm.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaForm.spec.js
@@ -157,6 +157,12 @@ describe('SchemaForm', () => {
       expect(wrapper.findAllComponents(FormText)).toHaveLength(3)
       expect(wrapper.findAllComponents(FormSelect)).toHaveLength(1)
     })
+
+    it('works with an empty array schema', () => {
+      const wrapper = mount(SchemaWrapperFactory([]))
+
+      expect(wrapper.find('form').exists()).toBe(true)
+    })
   })
 
   describe('default schema values', () => {


### PR DESCRIPTION
The validator for the schema property was not allowing an empty array schema to be passed, which
can be a "state" of a computed schema for example. This should suppress the warning as it would only
render an empty form.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
