### PR TITLE
fix(lookup, formvuelate): remapped nested

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@vue/cli-service": "^5.0.0-beta.2",
     "@vue/compiler-sfc": "^3.0.0-beta.12",
     "@vue/eslint-config-standard": "^6.1.0",
-    "@vue/test-utils": "^2.0.0-rc.4",
+    "@vue/test-utils": "^2.0.0-rc.16",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^27.0.6",
     "chalk": "^4.1.2",

--- a/packages/formvuelate/src/SchemaForm.vue
+++ b/packages/formvuelate/src/SchemaForm.vue
@@ -18,6 +18,8 @@
       :preventModelCleanupOnSchemaChange="preventModelCleanupOnSchemaChange"
     />
 
+    <pre v-if="debug">{{ parsedSchema }}</pre>
+
     <slot
       v-if="behaveLikeParentSchema"
       name="afterForm"
@@ -68,7 +70,8 @@ export default {
     useCustomFormWrapper: {
       type: Boolean,
       default: false
-    }
+    },
+    debug: { type: Boolean, default: false }
   },
   emits: ['submit', 'update:modelValue'],
   setup (props, { emit, attrs }) {

--- a/packages/formvuelate/src/SchemaFormFactory.js
+++ b/packages/formvuelate/src/SchemaFormFactory.js
@@ -33,7 +33,7 @@ export default function SchemaFormFactory (plugins = [], components = null) {
     if (components) {
       // If user defined local components to be used inside the SchemaForm
       // injected them so that SchemaField can use them if declared
-      if (!inject(INJECTED_LOCAL_COMPONENTS)) {
+      if (!inject(INJECTED_LOCAL_COMPONENTS, null)) {
         provide(INJECTED_LOCAL_COMPONENTS, components)
       }
     }
@@ -58,6 +58,7 @@ export default function SchemaFormFactory (plugins = [], components = null) {
       ...components,
       ...SchemaForm.components
     },
+    name: 'SchemaFormWithPlugins',
     // Return a customized setup function with plugins
     // as the new SchemaForm setup
     setup

--- a/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaFormFactory.e2e.js
@@ -116,6 +116,73 @@ describe('SchemaFormFactory', () => {
       cy.get('input').should('have.length', 4)
       cy.get('label').eq(3).should('have.text', 'Double nested text')
     })
+
+    it('works when also having to mapProps the component property and mapComponents', () => {
+      const SCHEMA = [
+        {
+          model: 'firstName',
+          type: 'Text',
+          label: 'First Name'
+        },
+        {
+          model: 'nested',
+          type: 'Container',
+          schema: [
+            {
+              model: 'nestedfirstName',
+              type: 'Text',
+              label: 'First Name nested'
+            },
+            {
+              model: 'nestedLastName',
+              type: BaseInput,
+              label: 'Last name nested'
+            },
+            {
+              model: 'doubleNested',
+              type: 'Container',
+              schema: [
+                {
+                  model: 'doubleNestedName',
+                  type: 'Text',
+                  label: 'Double nested text'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      const SchemaFormWithPlugins = SchemaFormFactory([
+        LookupPlugin({
+          mapProps: {
+            type: 'component'
+          },
+          mapComponents: {
+            Text: BaseInput,
+            Container: 'SchemaForm'
+          }
+        })
+      ])
+
+      mount({
+        components: { SchemaFormWithPlugins },
+        setup () {
+          const model = ref({})
+          lookupSubSchemas(SchemaFormWithPlugins)
+          useSchemaForm(model)
+
+          const schemaRef = shallowRef(SCHEMA)
+
+          return () => h(SchemaFormWithPlugins, {
+            schema: schemaRef
+          })
+        }
+      })
+
+      cy.get('input').should('have.length', 4)
+      cy.get('label').eq(3).should('have.text', 'Double nested text')
+    })
   })
 
   describe('with lookup and vee-validate', () => {
@@ -123,16 +190,16 @@ describe('SchemaFormFactory', () => {
       const SCHEMA = [
         {
           model: 'firstName',
-          component: 'Text',
+          type: 'Text',
           label: 'First Name'
         },
         {
           model: 'nested',
-          component: 'SchemaForm',
+          type: 'Container',
           schema: [
             {
               model: 'nestedfirstName',
-              component: 'Text',
+              type: 'Text',
               label: 'First Name nested',
               validations: value => value && value.length > 3
             }
@@ -142,8 +209,12 @@ describe('SchemaFormFactory', () => {
 
       const SchemaFormWithPlugins = SchemaFormFactory([
         LookupPlugin({
+          mapProps: {
+            type: 'component'
+          },
           mapComponents: {
-            Text: BaseInput
+            Text: BaseInput,
+            Container: 'SchemaForm'
           }
         }),
         VeeValidatePlugin({})

--- a/packages/formvuelate/tests/unit/ParsedSchema.spec.js
+++ b/packages/formvuelate/tests/unit/ParsedSchema.spec.js
@@ -1,18 +1,38 @@
 import useParsedSchema from '../../src/features/ParsedSchema'
 import SchemaForm from '../../src/SchemaForm'
+import { LOOKUP_PARSE_SUB_SCHEMA_FORMS } from '../../src/utils/constants'
 
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
+import { mount } from '@vue/test-utils'
+
+const factory = ({
+  schema,
+  model = null,
+  opts = {}
+}) => {
+  return mount({
+    name: 'ParsedSchemaComponent',
+    template: `
+      <div>{{ parsedSchema }}</div>
+    `,
+    setup () {
+      const { parsedSchema } = useParsedSchema(schema, model)
+
+      return { parsedSchema }
+    }
+  }, opts)
+}
 
 describe('ParsedSchema feature', () => {
   it('returns an empty schema if its not valid', () => {
     const schema = ref({})
+    const wrapper = factory({ schema })
 
-    const { parsedSchema } = useParsedSchema(schema)
-    expect(parsedSchema.value).toEqual([])
+    expect(wrapper.vm.parsedSchema).toEqual([])
   })
 
   it('returns the whole schema if the model requested is not found', () => {
-    const schema = ref({
+    const schema = shallowRef({
       someElement: {
         component: 'test'
       },
@@ -26,12 +46,44 @@ describe('ParsedSchema feature', () => {
       }
     })
 
-    const { parsedSchema } = useParsedSchema(schema, 'wrongModel')
-    expect(parsedSchema.value).toEqual(
+    const wrapper = factory({ schema, model: 'wrongModel' })
+
+    expect(wrapper.vm.parsedSchema).toEqual(
       [
         [expect.objectContaining({ component: 'test' })],
         [expect.objectContaining({ model: 'nestedModel' })]
       ]
+    )
+  })
+
+  it('calls the remapSubSchemaForms fn if it was provided by lookup', () => {
+    const schema = shallowRef({
+      someElement: {
+        component: 'test'
+      }
+    })
+
+    const remapSubSchemaForms = jest.fn()
+    const SchemaFormWithPlugins = { name: 'SFwP', template: '<div />' }
+
+    factory({
+      schema,
+      opts: {
+        global: {
+          provide: {
+            [LOOKUP_PARSE_SUB_SCHEMA_FORMS]: {
+              remapSubSchemaForms,
+              SchemaFormWithPlugins
+            }
+          }
+        }
+      }
+    })
+
+    expect(remapSubSchemaForms).toHaveBeenCalledTimes(1)
+    expect(remapSubSchemaForms).toHaveBeenCalledWith(
+      [[expect.objectContaining({ component: 'test', model: 'someElement' })]],
+      SchemaFormWithPlugins
     )
   })
 })

--- a/packages/formvuelate/tests/unit/SchemaField.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaField.spec.js
@@ -96,7 +96,7 @@ describe('SchemaField', () => {
   })
 
   it('uses the injected local components if available', () => {
-    const FormText = { name: 'LocalFormText' }
+    const FormText = { name: 'LocalFormText', template: '<input />' }
 
     const wrapper = mount(
       SchemaFieldWrapper(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,10 +2903,15 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.1.5.tgz#74ee3aad995d0a3996a6bb9533d4d280514ede03"
   integrity sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==
 
-"@vue/test-utils@^2.0.0-rc.10", "@vue/test-utils@^2.0.0-rc.4":
+"@vue/test-utils@^2.0.0-rc.10":
   version "2.0.0-rc.12"
   resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.12.tgz#716a84d915d6045640eeac416cc2a2acd514e06e"
   integrity sha512-G9BGRYlfwWjhorGjnpniC3hcYn1pCG2NqKG68fdUpk3DgWKordZ+BsEFD/SAmKdTZVMCY1huFwY3XAbPc+AgRw==
+
+"@vue/test-utils@^2.0.0-rc.16":
+  version "2.0.0-rc.16"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.16.tgz#59380f02870f856ac002a29c02681d3f3fcbafeb"
+  integrity sha512-TubikDVkI2LuRKRPSLv3lYpbpvvucT2DIcGqfBVpvYs4W19u0EBTJEdmfwmSuLY7H1TyAr9Stur3PI1sWWvTGQ==
 
 "@vue/vue-loader-v15@npm:vue-loader@^15.9.7":
   version "15.9.7"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When using `lookupSubSchemas` and mapProps/mapComponents at the same time a race condition happened.
Due to the lookupSubSchemas parsing function being called at ParsedSchema.js level, it silently "skipped" it if the component property was not found.

This required refactoring the approach into Lookup providing the actual function that needs to be executed when this happens, so that we can eagerly call it on ParsedSchema.js for scenarios where `lookupSubSchemas` is used _without_ the LookupPlugin being added to the plugin stack AND scenarios where the plugin is also added.

E2e tests have been added with scenarios to replicate the problem.