### PR TITLE
fix(lookup): types file extension in package.json

### DIFF
--- a/packages/plugin-lookup/package.json
+++ b/packages/plugin-lookup/package.json
@@ -37,5 +37,5 @@
   "module": "dist/formvuelate-plugin-lookup.es.js",
   "unpkg": "dist/formvuelate-plugin-lookup.umd.js",
   "browser": "dist/formvuelate-plugin-lookup.es.js",
-  "types": "dist/formvuelate-plugin-lookup.d.ts.js"
+  "types": "dist/formvuelate-plugin-lookup.d.ts"
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In the `package.json` of the lookup plugin, types are exported with `.d.ts.js` extension instead of `.d.ts`. In consequence, types of the plugin will not be recognized by the code editor (VSCode in my case). This pull request resolves this issue.