### PR TITLE
fix(vee-validate): use injected local components fix #253

### DIFF
--- a/packages/formvuelate/src/SchemaField.vue
+++ b/packages/formvuelate/src/SchemaField.vue
@@ -66,10 +66,9 @@ export default {
       return condition(formModel.value)
     })
 
+    // Possible local components injected by user from SchemaFormFactory
+    const locals = inject(INJECTED_LOCAL_COMPONENTS, {})
     const component = computed(() => {
-      // Possible local components injected by user from SchemaFormFactory
-      const locals = inject(INJECTED_LOCAL_COMPONENTS, {})
-
       return locals[props.field.component] || props.field.component
     })
 

--- a/packages/plugin-vee-validate/src/index.js
+++ b/packages/plugin-vee-validate/src/index.js
@@ -1,7 +1,7 @@
 import { toRefs, h, computed, markRaw, watch, getCurrentInstance, unref, resolveDynamicComponent, inject, provide } from 'vue'
 import { useForm, useField } from 'vee-validate'
 import { definePlugin, constants } from 'formvuelate'
-import { injectWithSelf } from './utils'
+
 /**
  * For a Schema, find the elements in each of the rows and remap the element with the given function
  * @param {Array} schema
@@ -34,7 +34,6 @@ export default function VeeValidatePlugin (opts) {
     const { attrs: formAttrs } = getCurrentInstance() || { attrs: {} }
     // try to retrieve vee-validate form from the root schema if possible
     let formContext = inject(VEE_VALIDATE_FVL_FORM_KEY, undefined)
-    const localComponents = injectWithSelf(constants.INJECTED_LOCAL_COMPONENTS, {})
 
     if (!formContext) {
       // if non-existent create one and provide it for nested schemas
@@ -79,7 +78,7 @@ export default function VeeValidatePlugin (opts) {
             mapProps,
             path
           },
-          component: withField(field, localComponents)
+          component: withField(field)
         }
       }
 
@@ -143,7 +142,7 @@ export default function VeeValidatePlugin (opts) {
 // very important to avoid re-creating components when re-rendering
 const COMPONENT_LOOKUP = new Map()
 
-function withField (el, localComponents) {
+function withField (el) {
   const Comp = el.component
 
   if (COMPONENT_LOOKUP.has(Comp)) {
@@ -189,6 +188,7 @@ function withField (el, localComponents) {
         })
       }
 
+      const localComponents = inject(constants.INJECTED_LOCAL_COMPONENTS, {})
       const resolvedComponent = resolveComponent(Comp, localComponents)
 
       return function renderWithField () {

--- a/packages/plugin-vee-validate/src/utils.js
+++ b/packages/plugin-vee-validate/src/utils.js
@@ -1,9 +1,0 @@
-import { getCurrentInstance, inject } from 'vue'
-/**
- * Includes same-component scope in the inject hierarch
- */
-export function injectWithSelf (symbol, def = undefined) {
-  const vm = getCurrentInstance()
-
-  return vm?.provides[symbol] || inject(symbol, def)
-}

--- a/packages/plugin-vee-validate/src/utils.js
+++ b/packages/plugin-vee-validate/src/utils.js
@@ -1,0 +1,9 @@
+import { getCurrentInstance, inject } from 'vue'
+/**
+ * Includes same-component scope in the inject hierarch
+ */
+export function injectWithSelf (symbol, def = undefined) {
+  const vm = getCurrentInstance()
+
+  return vm?.provides[symbol] || inject(symbol, def)
+}

--- a/packages/plugin-vee-validate/tests/integration/integration.spec.js
+++ b/packages/plugin-vee-validate/tests/integration/integration.spec.js
@@ -838,4 +838,45 @@ describe('FVL integration', () => {
     await flushPromises()
     expect(wrapper.find('span').text()).toBe('')
   })
+
+  // #253
+  it('renders local form factory components', async () => {
+    // setup global rules and error message generator
+    defineRule('required', (value) => !!value)
+    configure({
+      generateMessage: (ctx) => `${ctx.field} is REQUIRED`
+    })
+
+    const schema = {
+      firstName: {
+        label: 'First Name',
+        component: 'FormText',
+        validations: 'required'
+      }
+    }
+
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()], {
+      FormText
+    })
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup () {
+        const formData = ref({})
+        useSchemaForm(formData)
+
+        return {
+          schema
+        }
+      }
+    })
+
+    const input = wrapper.findComponent(FormText)
+    expect(input.exists()).toBe(true)
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR fixes the vee-validate plugin not rendering the local components registered by `SchemaFormFactory` due to the wrapping it does around the schema components.