### PR TITLE
feat: add props schemaRowSlim for show elements without a wrapper

### DIFF
--- a/docs/3.x/src/guide/schema-form.md
+++ b/docs/3.x/src/guide/schema-form.md
@@ -199,14 +199,6 @@ For cases where you need your components to be rendered without FormVueLate's de
 />
 ```
 
-Example output:
-
-```html
-
-<form>
-  [...]
-</form>
-
 ```
 ### preventModelCleanupOnSchemaChange
 

--- a/docs/3.x/src/guide/schema-form.md
+++ b/docs/3.x/src/guide/schema-form.md
@@ -188,9 +188,9 @@ Example output:
 </form>
 
 ```
-### schemaRowSlim
+### unwrappedRows
 
-If you need to display schema elements without a wrapper in `div.schema-row`, just add the `schemaRowSlim` property to the `SchemaForm` component.
+For cases where you need your components to be rendered without FormVueLate's default `.schema-row` wrapping div, add the `unwrappedRow` boolean property to `SchemaForm`. This can be explicitly set to `true`, or with Vue's boolean shorthand as in the following example.
 
 ```html
 <SchemaForm

--- a/docs/3.x/src/guide/schema-form.md
+++ b/docs/3.x/src/guide/schema-form.md
@@ -194,12 +194,11 @@ For cases where you need your components to be rendered without FormVueLate's de
 
 ```html
 <SchemaForm
-  schemaRowSlim
+  unwrappedRows
   :schema="mySchema"
 />
 ```
 
-```
 ### preventModelCleanupOnSchemaChange
 
 By default `SchemaForm` cleans up the value output of properties that are no longer present inside the schema every time the schema changes.

--- a/docs/3.x/src/guide/schema-form.md
+++ b/docs/3.x/src/guide/schema-form.md
@@ -188,6 +188,26 @@ Example output:
 </form>
 
 ```
+### schemaRowSlim
+
+If you need to display schema elements without a wrapper in `div.schema-row`, just add the `schemaRowSlim` property to the `SchemaForm` component.
+
+```html
+<SchemaForm
+  schemaRowSlim
+  :schema="mySchema"
+/>
+```
+
+Example output:
+
+```html
+
+<form>
+  [...]
+</form>
+
+```
 ### preventModelCleanupOnSchemaChange
 
 By default `SchemaForm` cleans up the value output of properties that are no longer present inside the schema every time the schema changes.

--- a/packages/formvuelate/src/SchemaForm.vue
+++ b/packages/formvuelate/src/SchemaForm.vue
@@ -14,6 +14,7 @@
       :key="index"
       :row="row"
       :schemaRowClasses="schemaRowClasses"
+      :schemaRowSlim="schemaRowSlim"
       :sharedConfig="sharedConfig"
       :preventModelCleanupOnSchemaChange="preventModelCleanupOnSchemaChange"
     />
@@ -72,7 +73,11 @@ export default {
       type: Boolean,
       default: false
     },
-    debug: { type: Boolean, default: false }
+    debug: { type: Boolean, default: false },
+    schemaRowSlim: {
+      type: Boolean,
+      default: false
+    }
   },
   emits: ['submit', 'update:modelValue'],
   setup (props, { emit, attrs }) {

--- a/packages/formvuelate/src/SchemaForm.vue
+++ b/packages/formvuelate/src/SchemaForm.vue
@@ -14,7 +14,7 @@
       :key="index"
       :row="row"
       :schemaRowClasses="schemaRowClasses"
-      :schemaRowSlim="schemaRowSlim"
+      :unwrappedRows="unwrappedRows"
       :sharedConfig="sharedConfig"
       :preventModelCleanupOnSchemaChange="preventModelCleanupOnSchemaChange"
     />
@@ -74,10 +74,7 @@ export default {
       default: false
     },
     debug: { type: Boolean, default: false },
-    schemaRowSlim: {
-      type: Boolean,
-      default: false
-    }
+    unwrappedRows: { type: Boolean, default: false }
   },
   emits: ['submit', 'update:modelValue'],
   setup (props, { emit, attrs }) {

--- a/packages/formvuelate/src/SchemaRow.vue
+++ b/packages/formvuelate/src/SchemaRow.vue
@@ -1,13 +1,14 @@
 <template>
   <template v-if="rowHasVisibleElements">
-    <SchemaField
-      v-if="unwrappedRows"
-      v-for="field in row"
-      :key="field.model"
-      :field="field"
-      v-bind="$attrs"
-      class="schema-col"
-    />
+    <template v-if="unwrappedRows">
+      <SchemaField
+        v-for="field in row"
+        :key="field.model"
+        :field="field"
+        v-bind="$attrs"
+        class="schema-col"
+      />
+    </template>
 
     <div
       v-else

--- a/packages/formvuelate/src/SchemaRow.vue
+++ b/packages/formvuelate/src/SchemaRow.vue
@@ -8,6 +8,7 @@
       v-bind="$attrs"
       class="schema-col"
     />
+
     <div
       v-else
       :class="['schema-row', schemaRowClasses]"

--- a/packages/formvuelate/src/SchemaRow.vue
+++ b/packages/formvuelate/src/SchemaRow.vue
@@ -1,16 +1,26 @@
 <template>
-  <div
-    v-if="rowHasVisibleElements"
-    :class="['schema-row', schemaRowClasses]"
-  >
+  <template v-if="rowHasVisibleElements">
     <SchemaField
+      v-if="schemaRowSlim"
       v-for="field in row"
       :key="field.model"
       :field="field"
       v-bind="$attrs"
       class="schema-col"
     />
-  </div>
+    <div
+      v-else
+      :class="['schema-row', schemaRowClasses]"
+    >
+      <SchemaField
+        v-for="field in row"
+        :key="field.model"
+        :field="field"
+        v-bind="$attrs"
+        class="schema-col"
+      />
+    </div>
+  </template>
 </template>
 
 <script>
@@ -31,6 +41,10 @@ export default {
     schemaRowClasses: {
       type: [String, Object, Array],
       default: null
+    },
+    schemaRowSlim: {
+      type: Boolean,
+      default: false
     }
   },
 

--- a/packages/formvuelate/src/SchemaRow.vue
+++ b/packages/formvuelate/src/SchemaRow.vue
@@ -1,7 +1,7 @@
 <template>
   <template v-if="rowHasVisibleElements">
     <SchemaField
-      v-if="schemaRowSlim"
+      v-if="unwrappedRows"
       v-for="field in row"
       :key="field.model"
       :field="field"
@@ -43,7 +43,7 @@ export default {
       type: [String, Object, Array],
       default: null
     },
-    schemaRowSlim: {
+    unwrappedRows: {
       type: Boolean,
       default: false
     }

--- a/packages/formvuelate/tests/unit/SchemaRow.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaRow.spec.js
@@ -63,8 +63,7 @@ describe('SchemaRow', () => {
           {
             model: 'FirstName',
             component: FormText,
-            label: 'First Name',
-            condition: model => false
+            label: 'First Name'
           },
           {
             model: 'LastName',
@@ -77,6 +76,6 @@ describe('SchemaRow', () => {
       }
     })
 
-    expect(wrapper.element.tagName).toBeUndefined()
+    expect(wrapper.findAllComponents(SchemaField).length).toBe(2)
   })
 })

--- a/packages/formvuelate/tests/unit/SchemaRow.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaRow.spec.js
@@ -68,8 +68,7 @@ describe('SchemaRow', () => {
           {
             model: 'LastName',
             component: FormText,
-            label: 'Last Name',
-            condition: model => false
+            label: 'Last Name'
           }
         ],
         schemaRowSlim: true
@@ -77,5 +76,6 @@ describe('SchemaRow', () => {
     })
 
     expect(wrapper.findAllComponents(SchemaField).length).toBe(2)
+    expect(wrapper.findAll('div').length).toBe(0)
   })
 })

--- a/packages/formvuelate/tests/unit/SchemaRow.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaRow.spec.js
@@ -56,7 +56,7 @@ describe('SchemaRow', () => {
     expect(wrapper.findAllComponents(SchemaField).length).toBe(2)
   })
 
-  it('doesnt render wrapper elements in slim mode', () => {
+  it('doesnt render wrapper elements when unwrappedRow is set', () => {
     const wrapper = shallowMount(SchemaRow, {
       props: {
         row: [

--- a/packages/formvuelate/tests/unit/SchemaRow.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaRow.spec.js
@@ -71,7 +71,7 @@ describe('SchemaRow', () => {
             label: 'Last Name'
           }
         ],
-        schemaRowSlim: true
+        unwrappedRows: true
       }
     })
 

--- a/packages/formvuelate/tests/unit/SchemaRow.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaRow.spec.js
@@ -55,4 +55,28 @@ describe('SchemaRow', () => {
 
     expect(wrapper.findAllComponents(SchemaField).length).toBe(2)
   })
+
+  it('doesnt render wrapper elements in slim mode', () => {
+    const wrapper = shallowMount(SchemaRow, {
+      props: {
+        row: [
+          {
+            model: 'FirstName',
+            component: FormText,
+            label: 'First Name',
+            condition: model => false
+          },
+          {
+            model: 'LastName',
+            component: FormText,
+            label: 'Last Name',
+            condition: model => false
+          }
+        ],
+        schemaRowSlim: true
+      }
+    })
+
+    expect(wrapper.element.tagName).toBeUndefined()
+  })
 })


### PR DESCRIPTION
This PR allows you to create forms that are more flexible from a visual point of view. By disabling the wrapping of each element, we can give them classes to fully control their layout and rebuilding in the adaptive. for example, using classes that describe css grid properties.

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/38465364/168841150-33f5c065-d9e5-42dc-9371-e301f89853e3.png">

This solves the issue we discussed https://github.com/formvuelate/formvuelate/issues/290


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
