### PR TITLE
feat(useSchemaForm): warn when called outside setup + dynamic-model docs (#302)

### DIFF
--- a/.changeset/salty-meteors-follow.md
+++ b/.changeset/salty-meteors-follow.md
@@ -1,0 +1,7 @@
+---
+'formvuelate': patch
+---
+
+Dev-only guard in useSchemaForm that emits a clear, actionable FormVueLate warning (pointing at the docs) when called without an active component instance. Matches the existing process.env/FormVueLate: convention in SchemaFormFactory.js.
+
+Refs #302

--- a/docs/4.x/guide/advanced-schema.md
+++ b/docs/4.x/guide/advanced-schema.md
@@ -247,3 +247,36 @@ updateFormModel('nested.phone', '555-555-555')
 console.log(model.value.nested.phone) // outputs 555-555-555
 ```
 
+## Dynamic and multi-step models
+
+`useSchemaForm` must be called **once, synchronously, inside your component's `setup()`**. Under the hood it uses Vue's `provide()`, which only works while a component is being set up. Calling it later — for example inside a click handler when switching tabs or steps — triggers the following warning, and the form's model will not be wired up:
+
+```
+[Vue warn]: provide() can only be used inside setup().
+```
+
+Instead of re-calling the composable, create a single model up front and change its **contents** as the user navigates. Point `useSchemaForm` at a `ref` and swap its `value`:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import { SchemaForm, useSchemaForm } from 'formvuelate'
+
+const step = ref(0)
+const contacts = ref([{ name: '', email: '' }])
+
+// Point useSchemaForm at a ref, then swap its value — never re-call the composable.
+const currentContact = ref(contacts.value[step.value])
+useSchemaForm(currentContact)
+
+function selectTab (index) {
+  step.value = index
+  currentContact.value = contacts.value[index]
+}
+</script>
+```
+
+:::tip
+For paginated, step-by-step forms, [`SchemaWizard`](/guide/schema-wizard.html) manages the active step for you while keeping a single model.
+:::
+

--- a/packages/formvuelate/src/features/useSchemaForm.js
+++ b/packages/formvuelate/src/features/useSchemaForm.js
@@ -1,8 +1,21 @@
-import { ref, isRef, provide } from 'vue'
+import { ref, isRef, provide, getCurrentInstance } from 'vue'
 import { findNestedFormModelProp, updateFormModel, deleteFormModelProperty } from '../utils/Helpers'
 import { UPDATE_FORM_MODEL, FIND_NESTED_FORM_MODEL_PROP, FORM_MODEL, DELETE_FORM_MODEL_PROP } from '../utils/constants'
 
 export default function useSchemaForm (initialFormValue = {}) {
+  // useSchemaForm relies on provide(), which Vue only allows synchronously
+  // inside setup(). Calling it from an event handler or async callback (e.g.
+  // to swap the model when switching tabs) fails with a cryptic Vue warning.
+  // Surface a clearer, actionable message before that happens. See #302.
+  if (process.env && process.env.NODE_ENV !== 'production' && !getCurrentInstance()) {
+    console.warn(
+      'FormVueLate: useSchemaForm() must be called synchronously inside setup(). ' +
+      'Calling it from an event handler or async callback fails because it relies on provide(). ' +
+      'For dynamic or multi-step forms, create the model once and update it with updateFormModel(). ' +
+      'See https://formvuelate.js.org/guide/advanced-schema.html#dynamic-and-multi-step-models'
+    )
+  }
+
   const formModel = isRef(initialFormValue) ? initialFormValue : ref(initialFormValue)
 
   provide(UPDATE_FORM_MODEL, updateFormModel)

--- a/packages/formvuelate/tests/unit/useSchemaForm.spec.js
+++ b/packages/formvuelate/tests/unit/useSchemaForm.spec.js
@@ -7,12 +7,23 @@ import useSchemaForm from '../../src/features/useSchemaForm'
 import { FORM_MODEL } from '../../src/utils/constants'
 import * as Helpers from '../../src/utils/Helpers'
 
+import { mount } from '@vue/test-utils'
 import * as Vue from 'vue'
 const { isRef, ref } = Vue
 
 describe('useSchemaForm', () => {
+  let warnSpy
+
   beforeEach(() => {
     Vue.provide.mockClear()
+    // Most tests here call useSchemaForm() outside of a component setup, which
+    // legitimately trips the #302 dev warning. Silence it by default and assert
+    // on it explicitly in the dedicated tests below.
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
   })
 
   it('makes the form model a ref if it isnt', () => {
@@ -58,6 +69,30 @@ describe('useSchemaForm', () => {
       'name',
       'Marina',
       'nested.path'
+    )
+  })
+
+  // #302: provide() only works inside setup(), so calling useSchemaForm() from
+  // an event handler or async callback silently breaks the form. Surface a
+  // clear dev-only warning instead of Vue's cryptic one.
+  it('warns when called outside of a component setup', () => {
+    useSchemaForm({})
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('useSchemaForm() must be called synchronously inside setup()')
+    )
+  })
+
+  it('does not warn when called inside a component setup', () => {
+    mount({
+      setup () {
+        useSchemaForm({})
+        return () => null
+      }
+    })
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('useSchemaForm() must be called synchronously inside setup()')
     )
   })
 })


### PR DESCRIPTION
## Problem
  `useSchemaForm` relies on Vue's `provide()`, which only works synchronously inside `setup()`. Calling it from an event handler or async callback (e.g. swapping the model when switching tabs) fails with the cryptic `[Vue warn]: provide() can only be used inside setup().` — see #302.
   
  ## Changes
  - **Dev-only guard** in `useSchemaForm` that emits a clear, actionable FormVueLate warning (pointing at the docs) when called without an active component instance. Matches the existing `process.env`/`FormVueLate:` convention in `SchemaFormFactory.js`.
  - **Docs**: new "Dynamic and multi-step models" section in `advanced-schema.md` showing the correct pattern — create the model once and swap a `ref`'s value rather than re-calling the composable.
  - **Tests**: warns-outside-setup / no-warn-inside-setup.
  
  Refs #302