### PR TITLE
fix: stop changeset bumping the docs dep to unpublished versions

### DIFF
--- a/docs/4.x/package.json
+++ b/docs/4.x/package.json
@@ -13,7 +13,7 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "formvuelate": "^4.0.1",
+    "formvuelate": "^4.0.0",
     "vitepress": "^1.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs:dev": "pnpm --filter=\"./docs/4.x\" run dev",
     "docs:build": "pnpm --filter=\"./docs/4.x\" run build",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && git checkout -- docs/4.x/package.json",
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs:dev": "pnpm --filter=\"./docs/4.x\" run dev",
     "docs:build": "pnpm --filter=\"./docs/4.x\" run build",
     "changeset": "changeset",
-    "version-packages": "changeset version && git checkout -- docs/4.x/package.json",
+    "version-packages": "git diff --quiet && git diff --cached --quiet && changeset version && git restore --source=HEAD --staged --worktree -- docs/4.x/package.json",
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
The docs package (fvl-docs) depends on the published formvuelate from npm — Netlify builds docs standalone and can't use workspace:*. Changesets' version step rewrites that range to the just-bumped version before it's published, so the release workflow's frozen install can't resolve it.

- Revert docs/4.x formvuelate dependency to ^4.0.0 so it matches the lockfile and unblocks publishing 4.0.1.
- version-packages now discards changeset's edit to docs/4.x/package.json via git checkout, so future bumps never touch it. The caret range still lets Netlify pull the latest published 4.x.