### PR TITLE
fix: keep all packages version-locked with changeset fixed

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,14 +2,14 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
-  "linked": [
+  "fixed": [
     [
       "formvuelate",
       "@formvuelate/plugin-vee-validate",
       "@formvuelate/plugin-lookup"
     ]
   ],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/packages/plugin-lookup/package.json
+++ b/packages/plugin-lookup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formvuelate/plugin-lookup",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "FormVueLate Lookup plugin",
   "license": "MIT",
   "type": "module",

--- a/packages/plugin-vee-validate/package.json
+++ b/packages/plugin-vee-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formvuelate/plugin-vee-validate",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "FormVueLate Vee-validate plugin",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Problem
  `formvuelate` published as 4.0.1 but `@formvuelate/plugin-vee-validate` and
  `@formvuelate/plugin-lookup` stayed at 4.0.0. Cause: the changeset config used
  `linked`, which only equalizes versions among packages *already* being
  released. The #302 changeset selected only `formvuelate`, so only it was
  released — `linked` had nothing to equalize and the plugins were left behind.
  
  ## Fix
  - Switch the package group from `linked` to `fixed` in `.changeset/config.json`.
    With `fixed`, any changeset touching any one of the three bumps all of them
    together to the same version — true lockstep, no manual multi-select.
  - Bump both plugins to 4.0.1 to match the already-published `formvuelate@4.0.1`.
    On release, `changeset publish` publishes the two plugins at 4.0.1 (it skips
    `formvuelate@4.0.1`, already on npm).
    