### PR TITLE
docs: add 4.0.1 changelog entries for the plugins

### DIFF
--- a/packages/plugin-lookup/CHANGELOG.md
+++ b/packages/plugin-lookup/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 4.0.1
+
+### Patch Changes
+
+- Version bump to keep the @formvuelate/* packages in lockstep with formvuelate@4.0.1. No functional changes.
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/plugin-vee-validate/CHANGELOG.md
+++ b/packages/plugin-vee-validate/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 4.0.1
+
+### Patch Changes
+
+- Version bump to keep the @formvuelate/* packages in lockstep with formvuelate@4.0.1. No functional changes.
+
 ## 4.0.0
 
 ### Major Changes


### PR DESCRIPTION
The lockstep 4.0.1 bump was applied manually (no changeset), so the plugin CHANGELOGs had no 4.0.1 section. The changesets release action couldn't find it and dumped the entire changelog into each GitHub Release. Add the missing 4.0.1 entries so the files are consistent and release-note extraction works.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/formvuelate/formvuelate/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
