### PR TITLE
feat(core): add SchemaArray for repeatable array fields

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,5 +13,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["fvl-docs"]
+  "ignore": ["fvl-docs"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/schema-array.md
+++ b/.changeset/schema-array.md
@@ -1,0 +1,7 @@
+---
+"formvuelate": minor
+---
+
+Add `SchemaArray`, a core field for repeatable/variable-length lists. Declare it directly in your schema (`{ friends: { component: SchemaArray, items } }`) anywhere in the schema, including dynamic schemas; `items` can be a group of fields (array of objects) or a single field (array of scalars), and arrays can nest. It owns the array as a real array in the model and stays strictly UI-agnostic, shipping no markup. Add/remove/reorder controls are your own components declared via `after` (per row) and `append` (once), which emit their intent (`add`/`remove`/`move`) for `SchemaArray` to perform. `min`/`max` are exposed as `canAdd`/`canRemove` to those controls.
+
+Also fixes a `process is not defined` crash when FormVueLate runs in the browser (the dev-only warnings now guard `typeof process`).

--- a/docs/4.x/.vitepress/config.ts
+++ b/docs/4.x/.vitepress/config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
             { text: 'Getting Started', link: '/guide/' },
             { text: 'SchemaForm', link: '/guide/schema-form' },
             { text: 'SchemaWizard', link: '/guide/schema-wizard' },
+            { text: 'SchemaArray', link: '/guide/arrays' },
             { text: 'Advanced schema', link: '/guide/advanced-schema' },
             { text: 'Accessibility', link: '/guide/accessibility' },
             { text: 'TypeScript', link: '/guide/typescript' }

--- a/docs/4.x/guide/arrays.md
+++ b/docs/4.x/guide/arrays.md
@@ -1,0 +1,269 @@
+---
+sidebarDepth: 3
+---
+# SchemaArray
+
+Sometimes a form isn't just a flat list of fields. You need a list of _things_, like a handful of team members, a few phone numbers, or the line items on an invoice, and you don't know up front how many there will be. The person filling it out might add five, or none at all.
+
+That's exactly what `SchemaArray` is for. It's a core FormVueLate component that lets you declare a **repeatable** piece of your form right inside your schema, and it keeps the value in your model as a real array.
+
+And like the rest of FormVueLate, `SchemaArray` doesn't care how anything looks. It ships no buttons, no wrappers, not a single pixel of markup of its own. You bring the components, you bring the layout, and `SchemaArray` quietly handles the bookkeeping: adding rows, removing them, and keeping every row wired to the right slice of your model.
+
+## The idea
+
+You declare `SchemaArray` like any other field. Give it a `component` of `SchemaArray`, and describe a single row with `items`:
+
+```js
+import { SchemaArray } from 'formvuelate'
+
+const schema = {
+  friends: {
+    component: SchemaArray,
+    items: {
+      name: { component: TextInput, label: 'Name' },
+      age: { component: NumberInput, label: 'Age' }
+    }
+  }
+}
+```
+
+Because it lives in your schema, you can put it wherever you need it (at the top, in the middle, or tucked inside another section), and it works with dynamic, computed schemas too. There's no special template wiring to remember.
+
+::: warning
+The input components in these examples (`TextInput`, `NumberInput`, etc.) are only here to illustrate the idea. They are **not** part of FormVueLate. Bring your own.
+:::
+
+## Two kinds of rows
+
+`items` describes one row, and its shape decides what kind of array you get.
+
+### A group (array of objects)
+
+When `items` is an object of fields, each row is a little form of its own, and every entry in your array is an object:
+
+```js
+friends: {
+  component: SchemaArray,
+  items: {
+    name: { component: TextInput, label: 'Name' },
+    age: { component: NumberInput, label: 'Age' }
+  }
+}
+```
+
+```js
+// formModel
+{ friends: [{ name: 'Ada', age: 36 }, { name: 'Grace', age: 45 }] }
+```
+
+### A scalar (array of primitives)
+
+When `items` is a single field, meaning it has its own `component`, each row is one input, and your array holds plain values:
+
+```js
+tags: {
+  component: SchemaArray,
+  items: { component: TextInput, label: 'Tag' }
+}
+```
+
+```js
+// formModel
+{ tags: ['vue', 'forms'] }
+```
+
+## Adding and removing rows
+
+Here's the part that makes `SchemaArray` a little different from what you might expect: it will not render an "Add" button for you. It has no opinion about what your buttons should look like, and it's not going to guess.
+
+Instead, you hand it your own control components, and they tell `SchemaArray` what to do by **emitting** an event. You get two props for this:
+
+- `after`: rendered after each row. This is where your "Remove" button goes (and reorder controls, if you want them). It emits `remove` and `move`.
+- `append`: rendered once, after the whole list. This is where your "Add" button goes. It emits `add`.
+
+Your components are just plain components. They emit, `SchemaArray` listens and does the actual work:
+
+```vue
+<!-- RemoveButton.vue -->
+<template>
+  <button type="button" :disabled="canRemove === false" @click="$emit('remove')">
+    Remove
+  </button>
+</template>
+
+<script setup>
+defineProps(['index', 'count', 'canRemove'])
+defineEmits(['remove', 'move'])
+</script>
+```
+
+```vue
+<!-- AddButton.vue -->
+<template>
+  <button type="button" :disabled="canAdd === false" @click="$emit('add')">
+    Add another
+  </button>
+</template>
+
+<script setup>
+defineProps(['count', 'canAdd'])
+defineEmits(['add'])
+</script>
+```
+
+Then you wire them up in the schema:
+
+```js
+import { SchemaArray } from 'formvuelate'
+import RemoveButton from './RemoveButton.vue'
+import AddButton from './AddButton.vue'
+
+const schema = {
+  friends: {
+    component: SchemaArray,
+    items: {
+      name: { component: TextInput, label: 'Name' },
+      age: { component: NumberInput, label: 'Age' }
+    },
+    after: RemoveButton,
+    append: AddButton
+  }
+}
+```
+
+And that's the whole dance. Click your Add button and a fresh row appears. Click a Remove button and that row disappears, while every other row keeps its own value.
+
+:::tip Why is "Add" a separate prop?
+You might wonder why the Add button lives in `append` instead of next to each row. It comes down to the empty case: when your array has zero rows, there are no rows to render an Add button _after_. `append` always renders, so there's always a way to add that first entry.
+:::
+
+If you leave both props off, `SchemaArray` simply renders the rows with no controls at all, which is a perfectly good read-only list.
+
+### What your control components receive
+
+So you can build smarter controls, `SchemaArray` passes a bit of context down as props:
+
+- `after` gets `index` (the row's position), `count` (how many rows there are), and `canRemove`. Emit `remove` to remove that row, or `move` with a direction (`-1` to move up, `1` to move down) to reorder it.
+- `append` gets `count` and `canAdd`. Emit `add` to append a new row.
+
+`canAdd` and `canRemove` come straight from the `min` and `max` you set, so you can disable a button instead of letting someone break the rules.
+
+## Limiting how many rows
+
+Set `min` and/or `max` to keep the list within bounds:
+
+```js
+friends: {
+  component: SchemaArray,
+  items: { /* ... */ },
+  after: RemoveButton,
+  append: AddButton,
+  min: 1,
+  max: 5
+}
+```
+
+`SchemaArray` won't add past `max` or remove below `min`, and it surfaces that state as `canAdd` / `canRemove` on your control components. And if the model starts out with fewer rows than `min`, `SchemaArray` seeds blank ones for you, so the form is valid from the very first render.
+
+## Nesting arrays
+
+An array row can contain another array. It's schema all the way down. Here's a list of teams, each with its own list of members:
+
+```js
+const schema = {
+  teams: {
+    component: SchemaArray,
+    items: {
+      name: { component: TextInput, label: 'Team name' },
+      members: {
+        component: SchemaArray,
+        items: { component: TextInput, label: 'Member' },
+        after: RemoveButton,
+        append: AddButton
+      }
+    },
+    after: RemoveButton,
+    append: AddButton
+  }
+}
+```
+
+```js
+// formModel
+{ teams: [{ name: 'Core', members: ['Ada', 'Grace'] }] }
+```
+
+## Putting it all together
+
+Here's an array sitting comfortably in the middle of an otherwise ordinary form:
+
+```vue
+<template>
+  <SchemaForm :schema="schema" />
+</template>
+
+<script setup>
+import { SchemaForm, SchemaArray, useSchemaForm } from 'formvuelate'
+import TextInput from './TextInput.vue'
+import AddButton from './AddButton.vue'
+import RemoveButton from './RemoveButton.vue'
+
+const { formModel } = useSchemaForm({
+  title: '',
+  friends: [{ name: 'Ada', role: 'Engineer' }],
+  tags: ['vue']
+})
+
+const schema = {
+  title: { component: TextInput, label: 'Title' },
+
+  // a group array, where each row is an object
+  friends: {
+    component: SchemaArray,
+    items: {
+      name: { component: TextInput, label: 'Name' },
+      role: { component: TextInput, label: 'Role' }
+    },
+    after: RemoveButton,
+    append: AddButton,
+    min: 1
+  },
+
+  // a scalar array, where each row is a single value
+  tags: {
+    component: SchemaArray,
+    items: { component: TextInput, label: 'Tag' },
+    after: RemoveButton,
+    append: AddButton
+  }
+}
+</script>
+```
+
+And `formModel` stays exactly the shape you'd expect:
+
+```js
+{
+  title: 'My team',
+  friends: [{ name: 'Ada', role: 'Engineer' }],
+  tags: ['vue']
+}
+```
+
+## Props reference
+
+### `items`
+
+**Required.** The schema for a single row. An object of fields gives you a group (array of objects). A single field descriptor gives you a scalar list (array of primitives).
+
+### `after`
+
+Optional. A component rendered after each row. Receives `index`, `count`, and `canRemove`. Emit `remove` to drop that row, or `move` (with `-1` / `1`) to reorder it.
+
+### `append`
+
+Optional. A component rendered once, after the list. Receives `count` and `canAdd`. Emit `add` to append a new row.
+
+### `min` / `max`
+
+Optional numbers that bound the list length. They surface as `canRemove` / `canAdd` on your control components, and `min` seeds blank rows when the model starts out short.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.27.9",
+    "@changesets/cli": "2.31.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "@vitest/coverage-v8": "^4.1.7",
     "@vue/compiler-sfc": "^3.5.12",

--- a/packages/formvuelate/src/SchemaArray.vue
+++ b/packages/formvuelate/src/SchemaArray.vue
@@ -132,6 +132,24 @@ export default {
       { deep: true }
     )
 
+    // If `min` increases at runtime (e.g. a computed schema raises it), pad the
+    // list up to the new minimum. Existing rows keep their keys, so they are
+    // not remounted; only the new blank entries are appended.
+    watch(
+      () => props.min,
+      () => {
+        const min = Number(props.min) || 0
+        if (rows.value.length >= min) return
+
+        const additions = []
+        while (rows.value.length + additions.length < min) {
+          additions.push({ key: keyCounter++, value: blankValue() })
+        }
+        rows.value = [...rows.value, ...additions]
+        emitValue()
+      }
+    )
+
     const canAdd = computed(() => props.max == null || rows.value.length < props.max)
     const canRemove = computed(() => props.min == null || rows.value.length > props.min)
 

--- a/packages/formvuelate/src/SchemaArray.vue
+++ b/packages/formvuelate/src/SchemaArray.vue
@@ -6,6 +6,7 @@
       class="schema-array-row"
     >
       <SchemaArrayRow
+        :key="isScalar ? 'scalar' : 'group'"
         :items="items"
         :modelValue="row.value"
         @update:modelValue="value => updateRow(row.key, value)"
@@ -47,7 +48,6 @@ import { INJECTED_LOCAL_COMPONENTS } from './utils/constants'
 export default {
   name: 'SchemaArray',
   components: { SchemaArrayRow },
-  inheritAttrs: false,
   props: {
     modelValue: {
       type: Array,
@@ -186,6 +186,7 @@ export default {
 
     return {
       rows,
+      isScalar,
       resolvedAfter,
       resolvedAppend,
       canAdd,

--- a/packages/formvuelate/src/SchemaArray.vue
+++ b/packages/formvuelate/src/SchemaArray.vue
@@ -1,0 +1,182 @@
+<template>
+  <div class="schema-array">
+    <div
+      v-for="(row, index) in rows"
+      :key="row.key"
+      class="schema-array-row"
+    >
+      <SchemaArrayRow
+        :items="items"
+        :modelValue="row.value"
+        @update:modelValue="value => updateRow(row.key, value)"
+      />
+      <component
+        :is="resolvedAfter"
+        v-if="resolvedAfter"
+        :index="index"
+        :count="rows.length"
+        :canRemove="canRemove"
+        @remove="removeRow(row.key)"
+        @move="direction => move(row.key, direction)"
+      />
+    </div>
+
+    <component
+      :is="resolvedAppend"
+      v-if="resolvedAppend"
+      :count="rows.length"
+      :canAdd="canAdd"
+      @add="add"
+    />
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, inject, onMounted } from 'vue'
+import SchemaArrayRow from './SchemaArrayRow.vue'
+import { INJECTED_LOCAL_COMPONENTS } from './utils/constants'
+
+/**
+ * A repeatable array field. Declared in a schema like any other field
+ * (`{ friends: { component: SchemaArray, items, after, append } }`), so it works
+ * anywhere in the schema and with dynamic schemas. It owns the whole array as a
+ * single leaf value (core has no array-path model) and ships NO markup of its
+ * own. Add/remove/reorder come from user-provided `after` (per row) and
+ * `append` (once) components declared in the schema, which emit their intent up.
+ */
+export default {
+  name: 'SchemaArray',
+  components: { SchemaArrayRow },
+  inheritAttrs: false,
+  props: {
+    modelValue: {
+      type: Array,
+      default: () => []
+    },
+    items: {
+      type: Object,
+      default: () => ({})
+    },
+    // User control components (component or local-component name).
+    after: {
+      type: [Object, Function, String],
+      default: null
+    },
+    append: {
+      type: [Object, Function, String],
+      default: null
+    },
+    min: {
+      type: Number,
+      default: null
+    },
+    max: {
+      type: Number,
+      default: null
+    }
+  },
+  emits: ['update:modelValue'],
+  setup (props, { emit }) {
+    const locals = inject(INJECTED_LOCAL_COMPONENTS, {})
+    const resolve = component =>
+      typeof component === 'string' ? locals[component] || component : component
+    const resolvedAfter = computed(() => (props.after ? resolve(props.after) : null))
+    const resolvedAppend = computed(() => (props.append ? resolve(props.append) : null))
+
+    const isScalar = computed(() => Boolean(props.items && props.items.component))
+    const blankValue = () => {
+      if (!isScalar.value) return {}
+      return props.items && 'default' in props.items ? props.items.default : undefined
+    }
+
+    let keyCounter = 0
+    let internal = false
+    const rows = ref([])
+
+    const toRows = value =>
+      (Array.isArray(value) ? value : []).map(entry => ({ key: keyCounter++, value: entry }))
+
+    // Build the row list, padding up to `min` with blank entries.
+    const seed = value => {
+      const base = toRows(value)
+      const min = Number(props.min) || 0
+      while (base.length < min) base.push({ key: keyCounter++, value: blankValue() })
+      return base
+    }
+
+    rows.value = seed(props.modelValue)
+
+    const emitValue = () => {
+      internal = true
+      emit(
+        'update:modelValue',
+        rows.value.map(row => row.value)
+      )
+    }
+
+    // If `min` padded entries the bound model doesn't have yet, push them up once.
+    onMounted(() => {
+      const current = Array.isArray(props.modelValue) ? props.modelValue.length : 0
+      if (rows.value.length !== current) emitValue()
+    })
+
+    watch(
+      () => props.modelValue,
+      value => {
+        if (internal) {
+          internal = false
+          return
+        }
+        rows.value = seed(value)
+      },
+      { deep: true }
+    )
+
+    const canAdd = computed(() => props.max == null || rows.value.length < props.max)
+    const canRemove = computed(() => props.min == null || rows.value.length > props.min)
+
+    const updateRow = (key, value) => {
+      const row = rows.value.find(entry => entry.key === key)
+      if (!row) return
+      row.value = value
+      emitValue()
+    }
+
+    const add = value => {
+      if (!canAdd.value) return
+      const entry = value !== undefined ? value : blankValue()
+      rows.value = [...rows.value, { key: keyCounter++, value: entry }]
+      emitValue()
+    }
+
+    const removeRow = key => {
+      if (!canRemove.value) return
+      rows.value = rows.value.filter(entry => entry.key !== key)
+      emitValue()
+    }
+
+    const move = (key, direction) => {
+      const from = rows.value.findIndex(entry => entry.key === key)
+      if (from === -1) return
+      const to = direction === 'up' || direction === -1 ? from - 1 : from + 1
+      if (to < 0 || to >= rows.value.length) return
+      const next = [...rows.value]
+      ;[next[from], next[to]] = [next[to], next[from]]
+      rows.value = next
+      emitValue()
+    }
+
+    return {
+      rows,
+      resolvedAfter,
+      resolvedAppend,
+      canAdd,
+      canRemove,
+      updateRow,
+      add,
+      removeRow,
+      move
+    }
+  }
+}
+</script>

--- a/packages/formvuelate/src/SchemaArrayRow.vue
+++ b/packages/formvuelate/src/SchemaArrayRow.vue
@@ -74,24 +74,13 @@ export default {
       provide(SCHEMA_MODEL_PATH, '')
       provide(IS_SCHEMA_WIZARD, false)
 
-      let internal = false
+      // The row's own model is the source of truth for its entry, so we emit
+      // upward on every change. There's no inbound sync to do: an external
+      // change to the array remounts the row (SchemaArray reseeds with fresh
+      // keys), which rebuilds this model from the new modelValue on setup.
       watch(
         model,
-        value => {
-          internal = true
-          emit('update:modelValue', { ...value })
-        },
-        { deep: true }
-      )
-      watch(
-        () => props.modelValue,
-        value => {
-          if (internal) {
-            internal = false
-            return
-          }
-          model.value = isObjectValue(value) ? { ...value } : {}
-        },
+        value => emit('update:modelValue', { ...value }),
         { deep: true }
       )
     }

--- a/packages/formvuelate/src/SchemaArrayRow.vue
+++ b/packages/formvuelate/src/SchemaArrayRow.vue
@@ -1,0 +1,102 @@
+<template>
+  <SchemaForm
+    v-if="!isScalar"
+    :schema="items"
+    useCustomFormWrapper
+  />
+  <component
+    :is="resolvedComponent"
+    v-else
+    v-bind="scalarProps"
+    :modelValue="modelValue"
+    @update:modelValue="value => $emit('update:modelValue', value)"
+  />
+</template>
+
+<script>
+import { ref, computed, watch, inject, provide } from 'vue'
+import SchemaForm from './SchemaForm.vue'
+import useSchemaForm from './features/useSchemaForm'
+import {
+  PARENT_SCHEMA_EXISTS,
+  SCHEMA_MODEL_PATH,
+  IS_SCHEMA_WIZARD,
+  INJECTED_LOCAL_COMPONENTS
+} from './utils/constants'
+
+const isObjectValue = value => value !== null && typeof value === 'object' && !Array.isArray(value)
+
+/**
+ * Renders a single array entry. When `items` describes a group (a map of
+ * fields), the entry is its own isolated root SchemaForm over a per-row
+ * model. Core has no array-path model, so each row owns a plain object and reports
+ * changes upward. When `items` is a single field (has `component`), the entry
+ * is that one component bound to the scalar element.
+ */
+export default {
+  name: 'SchemaArrayRow',
+  components: { SchemaForm },
+  props: {
+    items: {
+      type: Object,
+      default: () => ({})
+    },
+    modelValue: {
+      type: [Object, String, Number, Boolean, Array],
+      default: undefined
+    }
+  },
+  emits: ['update:modelValue'],
+  setup (props, { emit }) {
+    const isScalar = computed(() => Boolean(props.items && props.items.component))
+
+    // --- scalar row ---
+    const locals = inject(INJECTED_LOCAL_COMPONENTS, {})
+    const resolvedComponent = computed(() => {
+      const component = props.items && props.items.component
+      return typeof component === 'string' ? locals[component] || component : component
+    })
+    const scalarProps = computed(() => {
+      const { component, model, ...rest } = props.items || {}
+      void component
+      void model
+      return rest
+    })
+
+    // --- group row ---
+    // Set up the isolated model only for group rows. provide()/useSchemaForm()
+    // must run synchronously in setup, and `items` never changes shape for a
+    // given row, so a one-time branch is safe.
+    if (!isScalar.value) {
+      const model = ref(isObjectValue(props.modelValue) ? { ...props.modelValue } : {})
+      useSchemaForm(model)
+      provide(PARENT_SCHEMA_EXISTS, false)
+      provide(SCHEMA_MODEL_PATH, '')
+      provide(IS_SCHEMA_WIZARD, false)
+
+      let internal = false
+      watch(
+        model,
+        value => {
+          internal = true
+          emit('update:modelValue', { ...value })
+        },
+        { deep: true }
+      )
+      watch(
+        () => props.modelValue,
+        value => {
+          if (internal) {
+            internal = false
+            return
+          }
+          model.value = isObjectValue(value) ? { ...value } : {}
+        },
+        { deep: true }
+      )
+    }
+
+    return { isScalar, resolvedComponent, scalarProps }
+  }
+}
+</script>

--- a/packages/formvuelate/src/SchemaFormFactory.js
+++ b/packages/formvuelate/src/SchemaFormFactory.js
@@ -11,7 +11,7 @@ export default function SchemaFormFactory (plugins = [], components = null) {
 
   function extendSchemaFormProps (newProps) {
     if (!isObject(newProps)) {
-      if (process.env && process.env.NODE_ENV !== 'production') {
+      if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production') {
         console.warn('FormVueLate: extendSchemaFormProps can only receive a Vue props object')
       }
       return

--- a/packages/formvuelate/src/features/useSchemaForm.js
+++ b/packages/formvuelate/src/features/useSchemaForm.js
@@ -7,7 +7,7 @@ export default function useSchemaForm (initialFormValue = {}) {
   // inside setup(). Calling it from an event handler or async callback (e.g.
   // to swap the model when switching tabs) fails with a cryptic Vue warning.
   // Surface a clearer, actionable message before that happens. See #302.
-  if (process.env && process.env.NODE_ENV !== 'production' && !getCurrentInstance()) {
+  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production' && !getCurrentInstance()) {
     console.warn(
       'FormVueLate: useSchemaForm() must be called synchronously inside setup(). ' +
       'Calling it from an event handler or async callback fails because it relies on provide(). ' +

--- a/packages/formvuelate/src/index.js
+++ b/packages/formvuelate/src/index.js
@@ -1,5 +1,6 @@
 import SchemaForm from './SchemaForm.vue'
 import SchemaWizard from './SchemaWizard.vue'
+import SchemaArray from './SchemaArray.vue'
 import SchemaFormFactory from './SchemaFormFactory'
 import useSchemaForm from './features/useSchemaForm'
 import definePlugin from './features/DefinePlugin'
@@ -10,6 +11,7 @@ export default SchemaForm
 export {
   SchemaForm,
   SchemaWizard,
+  SchemaArray,
   SchemaFormFactory,
   useSchemaForm,
   definePlugin,

--- a/packages/formvuelate/src/types/index.d.ts
+++ b/packages/formvuelate/src/types/index.d.ts
@@ -90,6 +90,38 @@ declare const SchemaWizard: DefineComponent<{
 }> &
   FormSlots
 
+declare const SchemaArray: DefineComponent<{
+  modelValue: {
+    type: PropType<any[]>;
+    default: any;
+  };
+  // Per-row schema: an object of fields (repeatable group) or a single field
+  // descriptor (repeatable scalar).
+  items: {
+    type: PropType<FormObjectSchema | FieldSchema>;
+    default: any;
+  };
+  // User-provided control components (component or local-component name).
+  // `after` renders after each row and emits `remove` / `move`; `append`
+  // renders once and emits `add`.
+  after: {
+    type: PropType<Component | string>;
+    default: any;
+  };
+  append: {
+    type: PropType<Component | string>;
+    default: any;
+  };
+  min: {
+    type: PropType<number>;
+    default: any;
+  };
+  max: {
+    type: PropType<number>;
+    default: any;
+  };
+}>
+
 export declare function definePlugin(plugin: PluginFunction | { setup: PluginFunction, extend: PluginExtenderFunction }): PluginFunction;
 
 export declare const constants: {
@@ -105,5 +137,5 @@ export declare const constants: {
   INJECTED_LOCAL_COMPONENTS: string;
 };
 
-export { SchemaForm, SchemaWizard };
+export { SchemaForm, SchemaWizard, SchemaArray };
 export default SchemaForm;

--- a/packages/formvuelate/src/utils/Helpers.js
+++ b/packages/formvuelate/src/utils/Helpers.js
@@ -110,14 +110,18 @@ export const forEachPropInModel = (formModel, fn, path = '') => {
   for (const prop in rawModel) {
     const value = rawModel[prop]
 
-    if (typeof value === 'object' && value !== null) {
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
       // Recurse into the nested object using a per-prop local path. Crucially
-      // we do NOT return here — returning would skip every sibling prop that
+      // we do NOT return here, since returning would skip every sibling prop that
       // comes after the first nested object at this level.
       const nestedPath = path === '' ? prop : `${path}.${prop}`
       forEachPropInModel(value, fn, nestedPath)
       continue
     }
+
+    // Arrays are treated as a single leaf value (SchemaArray owns them as a
+    // whole). Recursing would walk numeric indices as if they were model props
+    // and let cleanup delete them, corrupting the array.
 
     fn(prop, value, path)
   }

--- a/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
@@ -1,0 +1,177 @@
+import SchemaForm from '../../../src/SchemaForm.vue'
+import SchemaArray from '../../../src/SchemaArray.vue'
+import useSchemaForm from '../../../src/features/useSchemaForm'
+import { ref, h } from 'vue'
+import { BaseInput } from '../../utils/components'
+
+// User-provided control components: they only emit, and SchemaArray ships none.
+const AddControl = {
+  props: ['count', 'canAdd'],
+  emits: ['add'],
+  render () {
+    return h(
+      'button',
+      { class: 'add', type: 'button', disabled: this.canAdd === false, onClick: () => this.$emit('add') },
+      'add'
+    )
+  }
+}
+
+const RemoveControl = {
+  props: ['index', 'count', 'canRemove'],
+  emits: ['remove', 'move'],
+  render () {
+    return h(
+      'button',
+      { class: 'remove', type: 'button', disabled: this.canRemove === false, onClick: () => this.$emit('remove') },
+      'remove'
+    )
+  }
+}
+
+const mountArrayForm = (schema, initial) =>
+  cy.mount({
+    setup () {
+      const model = ref(initial)
+      useSchemaForm(model)
+      return () =>
+        h('div', [h(SchemaForm, { schema }), h('pre', { class: 'model' }, JSON.stringify(model.value))])
+    }
+  })
+
+describe('SchemaArray', () => {
+  const groupSchema = {
+    friends: {
+      component: SchemaArray,
+      items: {
+        name: { component: BaseInput, label: 'Name' },
+        role: { component: BaseInput, label: 'Role' }
+      },
+      after: RemoveControl,
+      append: AddControl
+    }
+  }
+
+  it('renders a row per entry and adds new rows', () => {
+    mountArrayForm(groupSchema, { friends: [{ name: 'Ada', role: 'Engineer' }] })
+
+    cy.get('input').should('have.length', 2)
+    cy.get('.add').click()
+    cy.get('input').should('have.length', 4)
+    cy.get('.model').should('contain', '"name":"Ada"')
+  })
+
+  it('removes a row without bleeding its value onto the survivor', () => {
+    mountArrayForm(groupSchema, { friends: [{ name: 'Ada', role: 'Engineer' }] })
+
+    cy.get('.add').click()
+    cy.get('input').eq(2).type('Lin')
+    cy.get('.model').should('contain', '"name":"Lin"')
+
+    // Remove the FIRST row; the survivor (Lin) must keep its own value.
+    cy.get('.remove').eq(0).click()
+    cy.get('input').should('have.length', 2)
+    cy.get('input').eq(0).should('have.value', 'Lin')
+    cy.get('.model').should('contain', '"name":"Lin"')
+    cy.get('.model').should('not.contain', 'Ada')
+  })
+
+  it('adds, edits and removes scalar rows', () => {
+    const scalarSchema = {
+      tags: {
+        component: SchemaArray,
+        items: { component: BaseInput, label: 'Tag' },
+        after: RemoveControl,
+        append: AddControl
+      }
+    }
+
+    mountArrayForm(scalarSchema, { tags: ['vue'] })
+
+    cy.get('input').should('have.length', 1)
+    cy.get('.add').click()
+    cy.get('input').eq(1).type('react')
+    cy.get('.model').should('contain', '["vue","react"]')
+
+    cy.get('.remove').eq(0).click()
+    cy.get('input').should('have.length', 1)
+    cy.get('.model').should('contain', '["react"]')
+  })
+
+  it('gates add and remove with min and max', () => {
+    const gated = {
+      tags: {
+        component: SchemaArray,
+        items: { component: BaseInput },
+        after: RemoveControl,
+        append: AddControl,
+        min: 1,
+        max: 2
+      }
+    }
+
+    mountArrayForm(gated, { tags: ['a'] })
+
+    // at min -> cannot remove
+    cy.get('.remove').should('be.disabled')
+
+    cy.get('.add').click()
+    cy.get('input').should('have.length', 2)
+
+    // at max -> cannot add, can now remove
+    cy.get('.add').should('be.disabled')
+    cy.get('.remove').first().should('not.be.disabled')
+  })
+
+  it('seeds blank entries up to min', () => {
+    const gated = {
+      tags: {
+        component: SchemaArray,
+        items: { component: BaseInput },
+        after: RemoveControl,
+        append: AddControl,
+        min: 2
+      }
+    }
+
+    mountArrayForm(gated, { tags: [] })
+
+    cy.get('input').should('have.length', 2)
+  })
+
+  it('supports nested arrays', () => {
+    const nested = {
+      teams: {
+        component: SchemaArray,
+        items: {
+          name: { component: BaseInput, label: 'Team' },
+          members: {
+            component: SchemaArray,
+            items: { component: BaseInput },
+            after: RemoveControl,
+            append: AddControl
+          }
+        },
+        after: RemoveControl,
+        append: AddControl
+      }
+    }
+
+    mountArrayForm(nested, { teams: [{ name: 'A', members: ['x'] }] })
+
+    // team name + one member
+    cy.get('input').should('have.length', 2)
+    // the inner "members" add renders before the outer "teams" add
+    cy.get('.add').eq(0).click()
+    cy.get('input').should('have.length', 3)
+    cy.get('.model').should('contain', '"members"')
+  })
+
+  it('renders rows with no controls when after/append are omitted', () => {
+    mountArrayForm({ tags: { component: SchemaArray, items: { component: BaseInput } } }, { tags: ['a', 'b'] })
+
+    cy.get('input').should('have.length', 2)
+    cy.get('.add').should('not.exist')
+    cy.get('.remove').should('not.exist')
+  })
+})

--- a/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
@@ -1,7 +1,7 @@
 import SchemaForm from '../../../src/SchemaForm.vue'
 import SchemaArray from '../../../src/SchemaArray.vue'
 import useSchemaForm from '../../../src/features/useSchemaForm'
-import { ref, h } from 'vue'
+import { ref, computed, h } from 'vue'
 import { BaseInput } from '../../utils/components'
 
 // User-provided control components: they only emit, and SchemaArray ships none.
@@ -173,5 +173,34 @@ describe('SchemaArray', () => {
     cy.get('input').should('have.length', 2)
     cy.get('.add').should('not.exist')
     cy.get('.remove').should('not.exist')
+  })
+
+  it('pads the list when a dynamic schema raises min at runtime', () => {
+    cy.mount({
+      setup () {
+        const min = ref(1)
+        const model = ref({ tags: ['a'] })
+        useSchemaForm(model)
+        const schema = computed(() => ({
+          tags: {
+            component: SchemaArray,
+            items: { component: BaseInput },
+            after: RemoveControl,
+            append: AddControl,
+            min: min.value
+          }
+        }))
+        return () =>
+          h('div', [
+            h('button', { class: 'raise-min', type: 'button', onClick: () => { min.value = 3 } }, 'raise'),
+            h(SchemaForm, { schema: schema.value }),
+            h('pre', { class: 'model' }, JSON.stringify(model.value))
+          ])
+      }
+    })
+
+    cy.get('input').should('have.length', 1)
+    cy.get('.raise-min').click()
+    cy.get('input').should('have.length', 3)
   })
 })

--- a/packages/formvuelate/tests/unit/Helpers.spec.js
+++ b/packages/formvuelate/tests/unit/Helpers.spec.js
@@ -118,6 +118,22 @@ describe('Helpers', () => {
 
       expect(paths.sort()).toEqual(['a.x', 'b.y'])
     })
+
+    it('treats an array value as a single leaf (does not recurse into indices)', () => {
+      // SchemaArray owns arrays as a whole. Recursing would walk numeric
+      // indices as model props and let cleanup delete them, corrupting the
+      // array.
+      const model = ref({ tags: ['a', 'b'], name: 'x' })
+      const visited = []
+      forEachPropInModel(model, (prop, value, path) => {
+        visited.push({ key: path ? `${path}.${prop}` : prop, value })
+      })
+
+      const tags = visited.find(v => v.key === 'tags')
+      expect(tags.value).toEqual(['a', 'b'])
+      // no per-index entries like "tags.0"
+      expect(visited.some(v => v.key.startsWith('tags.'))).toBe(false)
+    })
   })
 
   describe('forEachSchemaElement', () => {

--- a/packages/formvuelate/tests/unit/SchemaArray.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaArray.spec.js
@@ -392,4 +392,31 @@ describe('SchemaArray', () => {
       }).not.toThrow()
     })
   })
+
+  describe('dynamic min (runtime schema changes)', () => {
+    it('pads the array when min increases at runtime', async () => {
+      const wrapper = mount(SchemaArray, {
+        props: { modelValue: ['a'], items: { component: TextInput }, min: 1 }
+      })
+      expect(wrapper.findAll('.text')).toHaveLength(1)
+
+      await wrapper.setProps({ min: 3 })
+      await flushPromises()
+
+      expect(wrapper.findAll('.text')).toHaveLength(3)
+      const emitted = wrapper.emitted('update:modelValue')
+      expect(emitted[emitted.length - 1][0]).toHaveLength(3)
+    })
+
+    it('does not shrink the array when min decreases', async () => {
+      const wrapper = mount(SchemaArray, {
+        props: { modelValue: ['a', 'b', 'c'], items: { component: TextInput }, min: 3 }
+      })
+
+      await wrapper.setProps({ min: 1 })
+      await flushPromises()
+
+      expect(wrapper.findAll('.text')).toHaveLength(3)
+    })
+  })
 })

--- a/packages/formvuelate/tests/unit/SchemaArray.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaArray.spec.js
@@ -419,4 +419,37 @@ describe('SchemaArray', () => {
       expect(wrapper.findAll('.text')).toHaveLength(3)
     })
   })
+
+  describe('attribute forwarding', () => {
+    it('keeps the schema-col layout class on its root', () => {
+      const model = ref({ tags: ['a'] })
+      const wrapper = mountForm(
+        { tags: { component: SchemaArray, items: { component: TextInput } } },
+        model
+      )
+
+      expect(wrapper.find('.schema-array').classes()).toContain('schema-col')
+    })
+  })
+
+  describe('dynamic item shape (runtime schema changes)', () => {
+    it('re-initialises a row when items flips from scalar to group', async () => {
+      const wrapper = mount(SchemaArray, {
+        props: { modelValue: ['a'], items: { component: TextInput } }
+      })
+      expect(wrapper.findAll('.text')).toHaveLength(1)
+
+      // flip the item shape from scalar to group at runtime
+      await wrapper.setProps({ items: { name: { component: TextInput } } })
+      await flushPromises()
+
+      // the row remounted as a group with its own model; editing writes an
+      // object into the entry rather than binding to the wrong model
+      await wrapper.find('.text').setValue('Ada')
+      await flushPromises()
+
+      const emitted = wrapper.emitted('update:modelValue')
+      expect(emitted[emitted.length - 1][0][0]).toEqual({ name: 'Ada' })
+    })
+  })
 })

--- a/packages/formvuelate/tests/unit/SchemaArray.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaArray.spec.js
@@ -3,6 +3,8 @@ import { ref } from 'vue'
 import flushPromises from 'flush-promises'
 import SchemaForm from '../../src/SchemaForm.vue'
 import SchemaArray from '../../src/SchemaArray.vue'
+import SchemaArrayRow from '../../src/SchemaArrayRow.vue'
+import SchemaFormFactory from '../../src/SchemaFormFactory'
 import useSchemaForm from '../../src/features/useSchemaForm'
 
 const TextInput = {
@@ -28,6 +30,32 @@ const AddControl = {
   props: ['count', 'canAdd'],
   emits: ['add'],
   template: `<button class="add" :disabled="canAdd === false" @click="$emit('add')">add</button>`
+}
+
+// Reorder control: up/down buttons that emit `move` with a direction.
+const ReorderControl = {
+  props: ['index', 'count', 'canRemove'],
+  emits: ['remove', 'move'],
+  template: `<span>
+    <button class="up" @click="$emit('move', -1)">up</button>
+    <button class="down" @click="$emit('move', 1)">down</button>
+  </span>`
+}
+
+// Controls that emit regardless of canAdd/canRemove, to exercise the guards.
+const ForceAdd = {
+  emits: ['add'],
+  template: `<button class="force-add" @click="$emit('add')">+</button>`
+}
+const ForceRemove = {
+  emits: ['remove'],
+  template: `<button class="force-remove" @click="$emit('remove')">-</button>`
+}
+
+// Append control that emits a preset value with `add`.
+const AddPreset = {
+  emits: ['add'],
+  template: `<button class="add-preset" @click="$emit('add', 'preset')">add preset</button>`
 }
 
 const mountForm = (schema, model) =>
@@ -200,6 +228,168 @@ describe('SchemaArray', () => {
 
       expect(model.value.teams[0].members).toHaveLength(2)
       expect(Array.isArray(model.value.teams)).toBe(true)
+    })
+  })
+
+  describe('reordering', () => {
+    const reorderSchema = {
+      tags: {
+        component: SchemaArray,
+        items: { component: TextInput },
+        after: ReorderControl,
+        append: AddControl
+      }
+    }
+
+    it('moves rows up and down', async () => {
+      const model = ref({ tags: ['a', 'b', 'c'] })
+      const wrapper = mountForm(reorderSchema, model)
+
+      await wrapper.findAll('.down')[0].trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toEqual(['b', 'a', 'c'])
+
+      await wrapper.findAll('.up')[2].trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toEqual(['b', 'c', 'a'])
+    })
+
+    it('ignores moves that fall out of bounds', async () => {
+      const model = ref({ tags: ['a', 'b'] })
+      const wrapper = mountForm(reorderSchema, model)
+
+      await wrapper.findAll('.up')[0].trigger('click')
+      await wrapper.findAll('.down')[1].trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toEqual(['a', 'b'])
+    })
+  })
+
+  describe('guards', () => {
+    it('does not add past max or remove below min even if a control emits', async () => {
+      const model = ref({ tags: ['a', 'b'] })
+      const wrapper = mountForm(
+        {
+          tags: {
+            component: SchemaArray,
+            items: { component: TextInput },
+            after: ForceRemove,
+            append: ForceAdd,
+            min: 2,
+            max: 2
+          }
+        },
+        model
+      )
+
+      await wrapper.find('.force-add').trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toHaveLength(2)
+
+      await wrapper.findAll('.force-remove')[0].trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toHaveLength(2)
+    })
+
+    it('adds an entry with the value emitted by the control', async () => {
+      const model = ref({ tags: ['a'] })
+      const wrapper = mountForm(
+        { tags: { component: SchemaArray, items: { component: TextInput }, append: AddPreset } },
+        model
+      )
+
+      await wrapper.find('.add-preset').trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toEqual(['a', 'preset'])
+    })
+
+    it('uses the item default when adding a blank scalar entry', async () => {
+      const model = ref({ tags: ['a'] })
+      const wrapper = mountForm(
+        { tags: { component: SchemaArray, items: { component: TextInput, default: 'new' }, append: AddControl } },
+        model
+      )
+
+      await wrapper.find('.add').trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toEqual(['a', 'new'])
+    })
+  })
+
+  describe('external model changes', () => {
+    it('reseeds scalar rows when the model changes from outside', async () => {
+      const model = ref({ tags: ['a'] })
+      const wrapper = mountForm(
+        { tags: { component: SchemaArray, items: { component: TextInput }, after: RemoveControl, append: AddControl } },
+        model
+      )
+
+      model.value.tags = ['x', 'y']
+      await flushPromises()
+
+      expect(wrapper.findAll('.text')).toHaveLength(2)
+      expect(wrapper.findAll('.text')[0].element.value).toBe('x')
+    })
+
+    it('reseeds a group row when the model changes from outside', async () => {
+      const model = ref({ friends: [{ name: 'Ada' }] })
+      const wrapper = mountForm(
+        {
+          friends: {
+            component: SchemaArray,
+            items: { name: { component: TextInput } },
+            after: RemoveControl,
+            append: AddControl
+          }
+        },
+        model
+      )
+
+      model.value.friends = [{ name: 'Grace' }]
+      await flushPromises()
+
+      expect(wrapper.find('.text').element.value).toBe('Grace')
+    })
+  })
+
+  describe('component resolution', () => {
+    it('resolves a string item component via the factory local components', () => {
+      const Form = SchemaFormFactory([], { FvlText: TextInput })
+      const wrapper = mount({
+        components: { Form },
+        setup () {
+          useSchemaForm(ref({ tags: ['a'] }))
+          return {
+            schema: { tags: { component: SchemaArray, items: { component: 'FvlText' } } }
+          }
+        },
+        template: '<Form :schema="schema" />'
+      })
+
+      expect(wrapper.find('.text').exists()).toBe(true)
+    })
+  })
+
+  describe('bare mounts (prop defaults)', () => {
+    it('renders with default props', () => {
+      const wrapper = mount(SchemaArray)
+      expect(wrapper.find('.schema-array').exists()).toBe(true)
+    })
+
+    it('SchemaArrayRow tolerates missing items and a non-object value', () => {
+      const wrapper = mount(SchemaArrayRow)
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('ignores updates and moves for unknown keys', () => {
+      const wrapper = mount(SchemaArray, {
+        props: { modelValue: ['a'], items: { component: TextInput } }
+      })
+
+      expect(() => {
+        wrapper.vm.updateRow('nope', 'x')
+        wrapper.vm.move('nope', 1)
+      }).not.toThrow()
     })
   })
 })

--- a/packages/formvuelate/tests/unit/SchemaArray.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaArray.spec.js
@@ -1,0 +1,205 @@
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import flushPromises from 'flush-promises'
+import SchemaForm from '../../src/SchemaForm.vue'
+import SchemaArray from '../../src/SchemaArray.vue'
+import useSchemaForm from '../../src/features/useSchemaForm'
+
+const TextInput = {
+  props: ['modelValue', 'label'],
+  emits: ['update:modelValue'],
+  template: `<input class="text" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`
+}
+
+const NumberInput = {
+  props: ['modelValue', 'label'],
+  emits: ['update:modelValue'],
+  template: `<input class="num" type="number" :value="modelValue" @input="$emit('update:modelValue', Number($event.target.value))" />`
+}
+
+// User-provided control components: they only EMIT, and SchemaArray ships none.
+const RemoveControl = {
+  props: ['index', 'count', 'canRemove'],
+  emits: ['remove', 'move'],
+  template: `<button class="remove" :disabled="canRemove === false" @click="$emit('remove')">remove</button>`
+}
+
+const AddControl = {
+  props: ['count', 'canAdd'],
+  emits: ['add'],
+  template: `<button class="add" :disabled="canAdd === false" @click="$emit('add')">add</button>`
+}
+
+const mountForm = (schema, model) =>
+  mount({
+    components: { SchemaForm },
+    setup () {
+      useSchemaForm(model)
+      return { schema }
+    },
+    template: '<SchemaForm :schema="schema" />'
+  })
+
+describe('SchemaArray', () => {
+  describe('group rows (array of objects)', () => {
+    const groupSchema = {
+      friends: {
+        component: SchemaArray,
+        items: { name: { component: TextInput }, age: { component: NumberInput } },
+        after: RemoveControl,
+        append: AddControl
+      }
+    }
+
+    it('renders a row per array entry from the model', () => {
+      const model = ref({ friends: [{ name: 'Ada', age: 36 }, { name: 'Grace', age: 45 }] })
+      const wrapper = mountForm(groupSchema, model)
+
+      expect(wrapper.findAll('.text')).toHaveLength(2)
+      expect(wrapper.findAll('.num')).toHaveLength(2)
+      expect(wrapper.findAll('.text')[0].element.value).toBe('Ada')
+    })
+
+    it('writes edits to the right element', async () => {
+      const model = ref({ friends: [{ name: 'Ada', age: 36 }] })
+      const wrapper = mountForm(groupSchema, model)
+
+      await wrapper.find('.text').setValue('Grace')
+      await flushPromises()
+
+      expect(model.value.friends[0]).toEqual({ name: 'Grace', age: 36 })
+    })
+
+    it('adds and removes entries, survivors keep their values', async () => {
+      const model = ref({ friends: [{ name: 'Ada', age: 36 }] })
+      const wrapper = mountForm(groupSchema, model)
+
+      await wrapper.find('.add').trigger('click')
+      await flushPromises()
+      expect(model.value.friends).toHaveLength(2)
+
+      await wrapper.findAll('.text')[1].setValue('Lin')
+      await flushPromises()
+      expect(model.value.friends).toEqual([{ name: 'Ada', age: 36 }, { name: 'Lin' }])
+
+      // Remove the first row; the survivor must keep its own value (no bleed).
+      await wrapper.findAll('.remove')[0].trigger('click')
+      await flushPromises()
+      expect(model.value.friends).toEqual([{ name: 'Lin' }])
+      expect(wrapper.find('.text').element.value).toBe('Lin')
+    })
+  })
+
+  describe('scalar rows (array of primitives)', () => {
+    const scalarSchema = {
+      tags: {
+        component: SchemaArray,
+        items: { component: TextInput },
+        after: RemoveControl,
+        append: AddControl
+      }
+    }
+
+    it('adds, edits and removes primitive entries', async () => {
+      const model = ref({ tags: ['vue'] })
+      const wrapper = mountForm(scalarSchema, model)
+
+      expect(wrapper.findAll('.text')).toHaveLength(1)
+
+      await wrapper.find('.add').trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toHaveLength(2)
+
+      await wrapper.findAll('.text')[1].setValue('react')
+      await flushPromises()
+      expect(model.value.tags).toEqual(['vue', 'react'])
+
+      await wrapper.findAll('.remove')[0].trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toEqual(['react'])
+    })
+  })
+
+  describe('min / max gating', () => {
+    const gatedSchema = {
+      tags: {
+        component: SchemaArray,
+        items: { component: TextInput },
+        after: RemoveControl,
+        append: AddControl,
+        min: 1,
+        max: 2
+      }
+    }
+
+    it('exposes canAdd / canRemove to the control components', async () => {
+      const model = ref({ tags: ['a'] })
+      const wrapper = mountForm(gatedSchema, model)
+
+      // at min -> cannot remove
+      expect(wrapper.find('.remove').attributes('disabled')).toBeDefined()
+
+      await wrapper.find('.add').trigger('click')
+      await flushPromises()
+      expect(model.value.tags).toHaveLength(2)
+
+      // at max -> cannot add
+      expect(wrapper.find('.add').attributes('disabled')).toBeDefined()
+    })
+
+    it('seeds blank entries up to min when the model is short', async () => {
+      const model = ref({ tags: [] })
+      mountForm(gatedSchema, model)
+      await flushPromises()
+
+      expect(model.value.tags).toHaveLength(1)
+    })
+  })
+
+  describe('no controls', () => {
+    it('renders rows only when no after/append are provided', () => {
+      const model = ref({ tags: ['a', 'b'] })
+      const wrapper = mountForm(
+        { tags: { component: SchemaArray, items: { component: TextInput } } },
+        model
+      )
+
+      expect(wrapper.findAll('.text')).toHaveLength(2)
+      expect(wrapper.find('.add').exists()).toBe(false)
+      expect(wrapper.find('.remove').exists()).toBe(false)
+    })
+  })
+
+  describe('nested arrays', () => {
+    it('supports an array inside an array row', async () => {
+      const model = ref({ teams: [{ name: 'A', members: ['x'] }] })
+      const schema = {
+        teams: {
+          component: SchemaArray,
+          items: {
+            name: { component: TextInput },
+            members: {
+              component: SchemaArray,
+              items: { component: TextInput },
+              after: RemoveControl,
+              append: AddControl
+            }
+          },
+          after: RemoveControl,
+          append: AddControl
+        }
+      }
+
+      const wrapper = mountForm(schema, model)
+      // team name + one member
+      expect(wrapper.findAll('.text')).toHaveLength(2)
+
+      // the inner members "add" renders before the outer teams "add"
+      await wrapper.findAll('.add')[0].trigger('click')
+      await flushPromises()
+
+      expect(model.value.teams[0].members).toHaveLength(2)
+      expect(Array.isArray(model.value.teams)).toBe(true)
+    })
+  })
+})

--- a/packages/formvuelate/tests/unit/SchemaFormFactory.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaFormFactory.spec.js
@@ -114,4 +114,29 @@ describe('SchemaFormFactory', () => {
       FormSelect
     })
   })
+
+  it('warns when a plugin passes a non-object to extendSchemaFormProps', () => {
+    warn.mockClear()
+    const badPlugin = () => {}
+    badPlugin.extend = ({ extendSchemaFormProps }) => extendSchemaFormProps('not-an-object')
+
+    SchemaFormFactory([badPlugin])
+
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('skips the dev warning when process is not defined (browser)', () => {
+    warn.mockClear()
+    const badPlugin = () => {}
+    badPlugin.extend = ({ extendSchemaFormProps }) => extendSchemaFormProps('not-an-object')
+
+    vi.stubGlobal('process', undefined)
+    try {
+      SchemaFormFactory([badPlugin])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+
+    expect(warn).not.toHaveBeenCalled()
+  })
 })

--- a/packages/plugin-lookup/src/index.js
+++ b/packages/plugin-lookup/src/index.js
@@ -181,7 +181,7 @@ const replacePropInElement = (el, prop, replacement, { preserveMappedProps = fal
   }
 
   if (!(prop in el)) {
-    if (process.env && process.env.NODE_ENV !== 'production') {
+    if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production') {
       console.warn(`LookupPlugin: property "${prop}" not found in`, el)
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.27.9
+        specifier: 2.31.0
         version: 2.31.0(@types/node@25.9.1)
       '@vitejs/plugin-vue':
         specifier: ^6.0.0


### PR DESCRIPTION
  ## What this adds

  `SchemaArray`, a new core component for building repeatable, variable-length lists in a form: arrays of objects (groups) and arrays of primitives (scalars), with nesting. You declare it right inside your schema, so it works anywhere in the form, including dynamic/computed schemas.

  Relates to #132 (repeatable array fields).

  ## How it works

  - **Declared in the schema** like any field: `{ friends: { component: SchemaArray, items } }`. No special template wiring.
  - **`items`** describes one row: an object of fields gives an array of objects, a single field gives an array of primitives. Arrays can nest.
  - **Strictly UI-agnostic.** `SchemaArray` renders no markup of its own. Add/remove/reorder controls are your own components, passed as `after` (per row) and `append` (once), which communicate by emitting `remove` / `move` / `add`. `min` and `max` are surfaced to those controls as `canRemove` / `canAdd`.
  - It keeps the value in the model as a real array, with each row owning an isolated sub-model so removals never bleed values onto neighbours.
  
  ## Also included

  - **Browser fix:** `useSchemaForm`, `SchemaFormFactory`, and the lookup plugin read `process.env.NODE_ENV` for dev-only warnings. `process` is  undefined in the browser, so this threw "process is not defined" and broke any Vite/browser consumer. Each check is now guarded behind `typeof  process`. (Separate commit.)
  - `forEachPropInModel` now treats array values as leaves so model cleanup cannot corrupt them.

  ## Versioning

  A changeset bumps `formvuelate`, `@formvuelate/plugin-lookup`, and `@formvuelate/plugin-vee-validate` together to 4.1.0 (the `fixed` group). The  `onlyUpdatePeerDependentsWhenOutOfRange` flag keeps that a minor rather than escalating the plugins to a major via their peer dependency, and  `@changesets/cli` is pinned so that behaviour stays stable.

  ## Testing

  - Unit tests for `SchemaArray` (group and scalar rows, add/edit/remove, no value bleed on removal, `min`/`max` gating, `min` seeding, nested arrays,  no-controls) plus a `forEachPropInModel` array-leaf case.
  - Cypress component (browser) tests covering the same behaviour end to end.
  - Full unit suite passing, `pnpm ci:lint` clean, core build and docs build green.
  
  ## Docs

  New guide page at `guide/arrays`, added to the sidebar under Essentials.
  
  ## Follow-up

  A live, interactive demo will be added to the docs page once 4.1.0 is published to npm (the docs site builds against the published package, so the
  demo cannot run until then).