### PR TITLE
docs(arrays): add live SchemaArray demos

### DIFF
--- a/docs/4.x/.vitepress/theme/components/ArrayAddButton.vue
+++ b/docs/4.x/.vitepress/theme/components/ArrayAddButton.vue
@@ -1,0 +1,21 @@
+<script setup>
+// Demo-only control for SchemaArray's `append` slot prop. It ships no markup of
+// its own, so the "Add" button is the consumer's component. It emits `add`;
+// SchemaArray performs the insert.
+defineProps({
+  count: { type: Number, default: 0 },
+  canAdd: { type: Boolean, default: true }
+})
+defineEmits(['add'])
+</script>
+
+<template>
+  <button
+    type="button"
+    class="fvl-button"
+    :disabled="canAdd === false"
+    @click="$emit('add')"
+  >
+    + Add
+  </button>
+</template>

--- a/docs/4.x/.vitepress/theme/components/ArrayGroupPlayground.vue
+++ b/docs/4.x/.vitepress/theme/components/ArrayGroupPlayground.vue
@@ -1,0 +1,36 @@
+<script setup>
+// SchemaArray demo: a GROUP array (each row is an object). Self-contained, with
+// its own model and a single SchemaForm over the one array. Components are
+// referenced by string name and resolved against the globally registered demo
+// components (FormText, SchemaArray, ArrayAddButton, ArrayRemoveButton).
+import { ref } from 'vue'
+import { useSchemaForm } from 'formvuelate'
+
+const formData = ref({
+  friends: [
+    { name: 'Ada', role: 'Engineer' },
+    { name: 'Grace', role: 'Designer' }
+  ]
+})
+useSchemaForm(formData)
+
+const schema = {
+  friends: {
+    component: 'SchemaArray',
+    items: {
+      name: { component: 'FormText', label: 'Name' },
+      role: { component: 'FormText', label: 'Role' }
+    },
+    after: 'ArrayRemoveButton',
+    append: 'ArrayAddButton',
+    min: 1
+  }
+}
+</script>
+
+<template>
+  <div class="fvl-demo">
+    <SchemaForm :schema="schema" />
+    <pre class="fvl-demo__model">{{ formData }}</pre>
+  </div>
+</template>

--- a/docs/4.x/.vitepress/theme/components/ArrayRemoveButton.vue
+++ b/docs/4.x/.vitepress/theme/components/ArrayRemoveButton.vue
@@ -1,0 +1,22 @@
+<script setup>
+// Demo-only control for SchemaArray's `after` slot prop (rendered per row).
+// SchemaArray ships no markup, so the "Remove" button is the consumer's
+// component. It emits `remove`; SchemaArray drops that row.
+defineProps({
+  index: { type: Number, default: 0 },
+  count: { type: Number, default: 0 },
+  canRemove: { type: Boolean, default: true }
+})
+defineEmits(['remove'])
+</script>
+
+<template>
+  <button
+    type="button"
+    class="fvl-button"
+    :disabled="canRemove === false"
+    @click="$emit('remove')"
+  >
+    Remove
+  </button>
+</template>

--- a/docs/4.x/.vitepress/theme/components/ArrayScalarPlayground.vue
+++ b/docs/4.x/.vitepress/theme/components/ArrayScalarPlayground.vue
@@ -1,0 +1,27 @@
+<script setup>
+// SchemaArray demo: a SCALAR array (each row is a single value). Self-contained,
+// with its own model and a single SchemaForm over the one array.
+import { ref } from 'vue'
+import { useSchemaForm } from 'formvuelate'
+
+const formData = ref({
+  tags: ['vue', 'forms']
+})
+useSchemaForm(formData)
+
+const schema = {
+  tags: {
+    component: 'SchemaArray',
+    items: { component: 'FormText', label: 'Tag' },
+    after: 'ArrayRemoveButton',
+    append: 'ArrayAddButton'
+  }
+}
+</script>
+
+<template>
+  <div class="fvl-demo">
+    <SchemaForm :schema="schema" />
+    <pre class="fvl-demo__model">{{ formData }}</pre>
+  </div>
+</template>

--- a/docs/4.x/.vitepress/theme/index.ts
+++ b/docs/4.x/.vitepress/theme/index.ts
@@ -1,5 +1,5 @@
 import DefaultTheme from 'vitepress/theme'
-import { SchemaForm } from 'formvuelate'
+import { SchemaForm, SchemaArray } from 'formvuelate'
 
 import FormText from './components/FormText.vue'
 import FormSelect from './components/FormSelect.vue'
@@ -12,6 +12,10 @@ import ConditionalComputedDemo from './components/ConditionalComputedDemo.vue'
 import ConditionalConditionDemo from './components/ConditionalConditionDemo.vue'
 import HundredNestedDemo from './components/HundredNestedDemo.vue'
 import WizardPlayground from './components/WizardPlayground.vue'
+import ArrayGroupPlayground from './components/ArrayGroupPlayground.vue'
+import ArrayScalarPlayground from './components/ArrayScalarPlayground.vue'
+import ArrayAddButton from './components/ArrayAddButton.vue'
+import ArrayRemoveButton from './components/ArrayRemoveButton.vue'
 
 import './styles/demos.css'
 
@@ -34,5 +38,10 @@ export default {
     app.component('ConditionalConditionDemo', ConditionalConditionDemo)
     app.component('HundredNestedDemo', HundredNestedDemo)
     app.component('WizardPlayground', WizardPlayground)
+    app.component('SchemaArray', SchemaArray)
+    app.component('ArrayGroupPlayground', ArrayGroupPlayground)
+    app.component('ArrayScalarPlayground', ArrayScalarPlayground)
+    app.component('ArrayAddButton', ArrayAddButton)
+    app.component('ArrayRemoveButton', ArrayRemoveButton)
   }
 }

--- a/docs/4.x/guide/arrays.md
+++ b/docs/4.x/guide/arrays.md
@@ -56,6 +56,52 @@ friends: {
 { friends: [{ name: 'Ada', age: 36 }, { name: 'Grace', age: 45 }] }
 ```
 
+Here it is running. Each row is its own little form. Add a friend, edit the fields, and remove a row (the last one stays put, because `min` is `1`):
+
+<DemoContainer>
+<template #demo>
+<ClientOnly>
+<ArrayGroupPlayground />
+</ClientOnly>
+</template>
+<template #code>
+
+```vue
+<script setup>
+import { SchemaForm, SchemaArray, useSchemaForm } from 'formvuelate'
+import FormText from './FormText.vue'
+import AddButton from './AddButton.vue'
+import RemoveButton from './RemoveButton.vue'
+
+const { formModel } = useSchemaForm({
+  friends: [
+    { name: 'Ada', role: 'Engineer' },
+    { name: 'Grace', role: 'Designer' }
+  ]
+})
+
+const schema = {
+  friends: {
+    component: SchemaArray,
+    items: {
+      name: { component: FormText, label: 'Name' },
+      role: { component: FormText, label: 'Role' }
+    },
+    after: RemoveButton,
+    append: AddButton,
+    min: 1
+  }
+}
+</script>
+
+<template>
+  <SchemaForm :schema="schema" />
+</template>
+```
+
+</template>
+</DemoContainer>
+
 ### A scalar (array of primitives)
 
 When `items` is a single field, meaning it has its own `component`, each row is one input, and your array holds plain values:
@@ -71,6 +117,43 @@ tags: {
 // formModel
 { tags: ['vue', 'forms'] }
 ```
+
+And here's the scalar version. Each row is a single input, and the model stays a plain array of values:
+
+<DemoContainer>
+<template #demo>
+<ClientOnly>
+<ArrayScalarPlayground />
+</ClientOnly>
+</template>
+<template #code>
+
+```vue
+<script setup>
+import { SchemaForm, SchemaArray, useSchemaForm } from 'formvuelate'
+import FormText from './FormText.vue'
+import AddButton from './AddButton.vue'
+import RemoveButton from './RemoveButton.vue'
+
+const { formModel } = useSchemaForm({ tags: ['vue', 'forms'] })
+
+const schema = {
+  tags: {
+    component: SchemaArray,
+    items: { component: FormText, label: 'Tag' },
+    after: RemoveButton,
+    append: AddButton
+  }
+}
+</script>
+
+<template>
+  <SchemaForm :schema="schema" />
+</template>
+```
+
+</template>
+</DemoContainer>
 
 ## Adding and removing rows
 

--- a/docs/4.x/package.json
+++ b/docs/4.x/package.json
@@ -13,7 +13,7 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "formvuelate": "^4.0.0",
+    "formvuelate": "^4.1.0",
     "vitepress": "^1.6.4"
   }
 }

--- a/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
@@ -276,6 +276,6 @@ describe('SchemaArray', () => {
     cy.get('.model').should('contain', 'Ada').and('contain', 'Grace')
     cy.get('.gremove').first().click()
     cy.get('.gtext').should('have.length', 4)
-    cy.get('.model').should('contain', 'Grace')
+    cy.get('.model').should('contain', 'Grace').and('not.contain', 'Ada')
   })
 })

--- a/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
@@ -222,7 +222,11 @@ describe('SchemaArray', () => {
       props: ['count', 'canAdd'],
       emits: ['add'],
       render () {
-        return h('button', { class: 'gadd', type: 'button', onClick: () => this.$emit('add') }, 'add')
+        return h(
+          'button',
+          { class: 'gadd', type: 'button', disabled: this.canAdd === false, onClick: () => this.$emit('add') },
+          'add'
+        )
       }
     }
     const GRemove = {

--- a/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/SchemaArray.e2e.js
@@ -203,4 +203,75 @@ describe('SchemaArray', () => {
     cy.get('.raise-min').click()
     cy.get('input').should('have.length', 3)
   })
+
+  // Mirrors the docs demo: component names are strings resolved against globally
+  // registered components, in a single SchemaForm over a single array.
+  it('works with string component names resolved globally (docs demo pattern)', () => {
+    const GText = {
+      props: ['modelValue', 'label'],
+      emits: ['update:modelValue'],
+      render () {
+        return h('input', {
+          class: 'gtext',
+          value: this.modelValue,
+          onInput: e => this.$emit('update:modelValue', e.target.value)
+        })
+      }
+    }
+    const GAdd = {
+      props: ['count', 'canAdd'],
+      emits: ['add'],
+      render () {
+        return h('button', { class: 'gadd', type: 'button', onClick: () => this.$emit('add') }, 'add')
+      }
+    }
+    const GRemove = {
+      props: ['index', 'count', 'canRemove'],
+      emits: ['remove'],
+      render () {
+        return h(
+          'button',
+          { class: 'gremove', type: 'button', disabled: this.canRemove === false, onClick: () => this.$emit('remove') },
+          'x'
+        )
+      }
+    }
+
+    cy.mount(
+      {
+        setup () {
+          const model = ref({
+            friends: [
+              { name: 'Ada', role: 'Engineer' },
+              { name: 'Grace', role: 'Designer' }
+            ]
+          })
+          useSchemaForm(model)
+          const schema = {
+            friends: {
+              component: 'SchemaArray',
+              items: {
+                name: { component: 'GText', label: 'Name' },
+                role: { component: 'GText', label: 'Role' }
+              },
+              after: 'GRemove',
+              append: 'GAdd',
+              min: 1
+            }
+          }
+          return () =>
+            h('div', [h(SchemaForm, { schema }), h('pre', { class: 'model' }, JSON.stringify(model.value))])
+        }
+      },
+      { global: { components: { SchemaArray, GText, GAdd, GRemove } } }
+    )
+
+    cy.get('.gtext').should('have.length', 4)
+    cy.get('.gadd').click()
+    cy.get('.gtext').should('have.length', 6)
+    cy.get('.model').should('contain', 'Ada').and('contain', 'Grace')
+    cy.get('.gremove').first().click()
+    cy.get('.gtext').should('have.length', 4)
+    cy.get('.model').should('contain', 'Grace')
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
   docs/4.x:
     devDependencies:
       formvuelate:
-        specifier: ^4.0.0
-        version: 4.0.0(vue@3.5.34(typescript@5.9.3))
+        specifier: ^4.1.0
+        version: 4.1.0(vue@3.5.34(typescript@5.9.3))
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.52.1)(@types/node@25.9.1)(postcss@8.5.15)(search-insights@2.17.3)(typescript@5.9.3)
@@ -1897,8 +1897,8 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
-  formvuelate@4.0.0:
-    resolution: {integrity: sha512-U5EGDyUE4Pi+tcyEnYN0BR2wlfx8vQuLNi1ltWb65UCMSH24SOVgn5YoZfsX8HAHgn+4ddT0vv4rJ9J5VTxpdg==}
+  formvuelate@4.1.0:
+    resolution: {integrity: sha512-UDwTmWn7C0AG7htU86AyqnUCxl8CjS4JnQaub+yOxMqZuF3W2tqdkUA+C6eQbLi23nB2lymOU1tIuvMrnCNS+g==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       vue: ^3.4.0
@@ -5167,7 +5167,7 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
-  formvuelate@4.0.0(vue@3.5.34(typescript@5.9.3)):
+  formvuelate@4.1.0(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       vue: 3.5.34(typescript@5.9.3)
 


### PR DESCRIPTION
Adds two live, interactive demos to the SchemaArray guide, one under
  each array-type section.

  - A group-array demo (friends: name + role), with min: 1 so the last
    row can't be removed.
  - A scalar-array demo (tags).

  Each demo is self-contained: its own model and a single SchemaForm
  over one array, so there's no shared-model interference. New theme
  components ArrayGroupPlayground, ArrayScalarPlayground, ArrayAddButton
  and ArrayRemoveButton, registered globally alongside SchemaArray.