### PR TITLE
feat(vee-validate): expose form-level validation via v-model:validation

### DIFF
--- a/.changeset/validation-v-model.md
+++ b/.changeset/validation-v-model.md
@@ -1,0 +1,8 @@
+---
+"formvuelate": minor
+"@formvuelate/plugin-vee-validate": minor
+---
+
+Expose the form-level validation state outside `SchemaForm`. The vee-validate plugin now emits an `update:validation` event (usable as `v-model:validation`) carrying the same `errors`, `values`, `isSubmitting`, `submitCount` and `meta` object that the `#beforeForm` / `#afterForm` slot prop already provides. The state is seeded on mount and refreshed on every change, and only the root schema form emits it so nested schemas stay quiet.
+
+To support this, plugins can now extend the generated component's declared events through a new `extendEmits` helper passed alongside `extendSchemaFormProps` to a plugin's `extend` hook.

--- a/docs/4.x/guide/veevalidate.md
+++ b/docs/4.x/guide/veevalidate.md
@@ -513,7 +513,7 @@ For those cases the plugin also emits the form-level validation state through an
   />
 
   <!-- anywhere else, completely outside the form -->
-  <button :disabled="!validation.meta.valid">
+  <button :disabled="!validation.meta?.valid">
     Save
   </button>
 </template>
@@ -527,6 +527,8 @@ const schema = ref({ /* ... */ })
 ```
 
 The bound object carries the exact same properties as the slot prop: `errors`, `values`, `isSubmitting`, `submitCount` and `meta`. It is seeded with the initial state as soon as the form mounts, and refreshes on every change, so any reactive UI you point at it stays in sync.
+
+Notice the `?.` in the example. Your `ref` starts as an empty object and is only populated once the form mounts and emits, so reach for nested keys like `meta.valid` with optional chaining to stay safe on that very first render.
 
 If you only care about reacting to changes and do not need to keep the value around, skip `v-model` and listen to the event directly:
 

--- a/docs/4.x/guide/veevalidate.md
+++ b/docs/4.x/guide/veevalidate.md
@@ -498,3 +498,41 @@ Learn more about [accessible disabling of form buttons](https://css-tricks.com/m
   </template>
 </SchemaForm>
 ```
+
+## Accessing validation state outside the form <Badge text="4.2.0" type="warning" vertical="middle" />
+
+The slot props above are perfect when the UI that reacts to validation lives inside the `SchemaForm`. But sooner or later you will want that same state somewhere else on the page, think of a submit button pinned to a sticky footer, or a progress indicator in a sidebar that sits well outside the form element.
+
+For those cases the plugin also emits the form-level validation state through an `update:validation` event, so you can bind it with `v-model:validation` and use it anywhere in your template:
+
+```html
+<template>
+  <SchemaFormWithValidation
+    :schema="schema"
+    v-model:validation="validation"
+  />
+
+  <!-- anywhere else, completely outside the form -->
+  <button :disabled="!validation.meta.valid">
+    Save
+  </button>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const validation = ref({})
+const schema = ref({ /* ... */ })
+</script>
+```
+
+The bound object carries the exact same properties as the slot prop: `errors`, `values`, `isSubmitting`, `submitCount` and `meta`. It is seeded with the initial state as soon as the form mounts, and refreshes on every change, so any reactive UI you point at it stays in sync.
+
+If you only care about reacting to changes and do not need to keep the value around, skip `v-model` and listen to the event directly:
+
+```html
+<SchemaFormWithValidation
+  :schema="schema"
+  @update:validation="onValidationChange"
+/>
+```

--- a/packages/formvuelate/src/SchemaFormFactory.js
+++ b/packages/formvuelate/src/SchemaFormFactory.js
@@ -8,7 +8,7 @@ export default function SchemaFormFactory (plugins = [], components = null) {
   const originalSetup = SchemaForm.setup
 
   const schemaFormProps = { ...SchemaForm.props }
-  const schemaFormEmits = [...(SchemaForm.emits || [])]
+  const schemaFormEmits = [...SchemaForm.emits]
 
   function extendSchemaFormProps (newProps) {
     if (!isObject(newProps)) {

--- a/packages/formvuelate/src/SchemaFormFactory.js
+++ b/packages/formvuelate/src/SchemaFormFactory.js
@@ -8,6 +8,7 @@ export default function SchemaFormFactory (plugins = [], components = null) {
   const originalSetup = SchemaForm.setup
 
   const schemaFormProps = { ...SchemaForm.props }
+  const schemaFormEmits = [...(SchemaForm.emits || [])]
 
   function extendSchemaFormProps (newProps) {
     if (!isObject(newProps)) {
@@ -20,9 +21,22 @@ export default function SchemaFormFactory (plugins = [], components = null) {
     Object.assign(schemaFormProps, newProps)
   }
 
+  function extendEmits (newEmits) {
+    if (!Array.isArray(newEmits)) {
+      if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production') {
+        console.warn('FormVueLate: extendEmits can only receive an array of event names')
+      }
+      return
+    }
+
+    newEmits.forEach(name => {
+      if (!schemaFormEmits.includes(name)) schemaFormEmits.push(name)
+    })
+  }
+
   plugins.forEach(plugin => {
     if (plugin.extend) {
-      plugin.extend({ extendSchemaFormProps })
+      plugin.extend({ extendSchemaFormProps, extendEmits })
     }
   })
 
@@ -54,6 +68,7 @@ export default function SchemaFormFactory (plugins = [], components = null) {
   return {
     ...SchemaForm,
     props: schemaFormProps,
+    emits: schemaFormEmits,
     components: {
       ...components,
       ...SchemaForm.components

--- a/packages/formvuelate/src/types/index.d.ts
+++ b/packages/formvuelate/src/types/index.d.ts
@@ -14,6 +14,7 @@ export type FormObjectSchema = Record<string, FieldSchema>;
 
 interface PluginExtensionFunctions {
   extendFormProps(extendedProps: Record<string, any>): void;
+  extendEmits(emits: string[]): void;
 }
 
 export type PluginExtenderFunction = (extensions: PluginExtensionFunctions) => unknown;

--- a/packages/formvuelate/tests/e2e/specs/VeeValidate.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/VeeValidate.e2e.js
@@ -122,4 +122,46 @@ describe('vee-validate plugin (browser)', () => {
 
     cy.get('.submit-count').should('have.text', '0')
   })
+
+  it('exposes form-level validation state outside the form via v-model:validation', () => {
+    const SchemaWithValidation = SchemaFormFactory([VeeValidatePlugin()])
+
+    cy.mount({
+      components: { SchemaWithValidation },
+      setup () {
+        useSchemaForm(ref({}))
+        const schema = shallowRef({
+          email: {
+            component: BaseInput,
+            label: 'Email',
+            validations: yup.string().required(REQUIRED).email(EMAIL)
+          }
+        })
+        const validation = ref({})
+
+        // The button and error summary are siblings of the form, not slot
+        // content, so they can only react thanks to the emitted state.
+        return () => [
+          h(SchemaWithValidation, {
+            schema,
+            'onUpdate:validation': v => { validation.value = v }
+          }),
+          h('button', {
+            class: 'outside-submit',
+            disabled: !validation.value?.meta?.valid
+          }, 'Submit'),
+          h('span', { class: 'outside-error' }, validation.value?.errors?.email || '')
+        ]
+      }
+    })
+
+    cy.get('input').type('notanemail')
+    cy.get('.outside-error').should('have.text', EMAIL)
+    cy.get('button.outside-submit').should('be.disabled')
+
+    cy.get('input').clear()
+    cy.get('input').type('marina@test.com')
+    cy.get('.outside-error').should('have.text', '')
+    cy.get('button.outside-submit').should('not.be.disabled')
+  })
 })

--- a/packages/formvuelate/tests/unit/SchemaFormFactory.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaFormFactory.spec.js
@@ -139,4 +139,43 @@ describe('SchemaFormFactory', () => {
 
     expect(warn).not.toHaveBeenCalled()
   })
+
+  it('lets a plugin add events via extendEmits, preserving and de-duping', () => {
+    const plugin = () => {}
+    // includes a brand new event, an event already declared by SchemaForm,
+    // and a duplicate, to exercise both sides of the de-dupe check.
+    plugin.extend = ({ extendEmits }) => extendEmits(['custom-event', 'submit', 'custom-event'])
+
+    const factory = SchemaFormFactory([plugin])
+
+    expect(factory.emits).toContain('custom-event')
+    expect(factory.emits).toContain('submit')
+    expect(factory.emits.filter(e => e === 'custom-event')).toHaveLength(1)
+    expect(factory.emits.filter(e => e === 'submit')).toHaveLength(1)
+  })
+
+  it('warns when a plugin passes a non-array to extendEmits', () => {
+    warn.mockClear()
+    const badPlugin = () => {}
+    badPlugin.extend = ({ extendEmits }) => extendEmits('not-an-array')
+
+    SchemaFormFactory([badPlugin])
+
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('skips the extendEmits dev warning when process is not defined (browser)', () => {
+    warn.mockClear()
+    const badPlugin = () => {}
+    badPlugin.extend = ({ extendEmits }) => extendEmits('not-an-array')
+
+    vi.stubGlobal('process', undefined)
+    try {
+      SchemaFormFactory([badPlugin])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+
+    expect(warn).not.toHaveBeenCalled()
+  })
 })

--- a/packages/plugin-vee-validate/src/index.js
+++ b/packages/plugin-vee-validate/src/index.js
@@ -26,7 +26,7 @@ export default function VeeValidatePlugin (opts) {
   // Maps the validation state exposed by vee-validate to components
   const mapProps = (opts && opts.mapProps) || defaultMapProps
 
-  function veeValidatePlugin (baseReturns, props) {
+  function veeValidatePlugin (baseReturns, props, context) {
     // Take the parsed schema from SchemaForm setup returns
     const { parsedSchema, formBinds } = baseReturns
 
@@ -34,6 +34,10 @@ export default function VeeValidatePlugin (opts) {
     const { attrs: formAttrs } = getCurrentInstance() || { attrs: {} }
     // try to retrieve vee-validate form from the root schema if possible
     let formContext = inject(VEE_VALIDATE_FVL_FORM_KEY, undefined)
+    // Only the schema form that creates the vee-validate context (the root) owns
+    // the form-level state, so only it should publish it via `update:validation`.
+    // Nested schema forms reuse the injected context and must stay silent.
+    const isRootForm = !formContext
 
     if (!formContext) {
       // if non-existent create one and provide it for nested schemas
@@ -109,6 +113,29 @@ export default function VeeValidatePlugin (opts) {
       formSubmit(evt)
     })
 
+    // The form-level validation state, shared between the `validation` slot prop
+    // and the `update:validation` event so the two can never drift apart.
+    const validation = computed(() => {
+      return {
+        errors: formContext.errors.value,
+        values: formContext.values,
+        isSubmitting: formContext.isSubmitting.value,
+        submitCount: formContext.submitCount.value,
+        meta: formContext.meta.value
+      }
+    })
+
+    // Publish the validation state to the parent scope so it can be consumed
+    // outside the form via `v-model:validation` (or a plain `@update:validation`
+    // listener). `immediate` seeds the parent with the initial state on mount.
+    if (isRootForm && context && typeof context.emit === 'function') {
+      watch(
+        validation,
+        value => context.emit('update:validation', value),
+        { deep: true, immediate: true }
+      )
+    }
+
     return {
       ...baseReturns,
       formBinds: computed(() => {
@@ -120,27 +147,27 @@ export default function VeeValidatePlugin (opts) {
       slotBinds: computed(() => {
         return {
           ...baseReturns.slotBinds.value,
-          validation: {
-            errors: formContext.errors.value,
-            values: formContext.values,
-            isSubmitting: formContext.isSubmitting.value,
-            submitCount: formContext.submitCount.value,
-            meta: formContext.meta.value
-          }
+          validation: validation.value
         }
       }),
       parsedSchema: formSchemaWithVeeValidate
     }
   }
 
-  // extends the schema form props
-  const extend = ({ extendSchemaFormProps }) => {
+  // extends the schema form props and emits
+  const extend = ({ extendSchemaFormProps, extendEmits }) => {
     extendSchemaFormProps({
       validationSchema: {
         type: Object,
         default: undefined
       }
     })
+
+    // Allows `v-model:validation` / `@update:validation` on the generated
+    // SchemaForm so the form-level validation state can be read outside it.
+    if (typeof extendEmits === 'function') {
+      extendEmits(['update:validation'])
+    }
   }
 
   return definePlugin({

--- a/packages/plugin-vee-validate/src/index.js
+++ b/packages/plugin-vee-validate/src/index.js
@@ -128,6 +128,11 @@ export default function VeeValidatePlugin (opts) {
     // Publish the validation state to the parent scope so it can be consumed
     // outside the form via `v-model:validation` (or a plain `@update:validation`
     // listener). `immediate` seeds the parent with the initial state on mount.
+    // `deep` is required, not redundant: the computed reads `formContext.values`
+    // shallowly (a plain property access, not a tracked ref), so it does not
+    // recompute when a field value mutates in place. Without `deep` the watcher
+    // would miss those changes and the emitted `values` would go stale between
+    // validity flips.
     if (isRootForm && context && typeof context.emit === 'function') {
       watch(
         validation,

--- a/packages/plugin-vee-validate/src/index.js
+++ b/packages/plugin-vee-validate/src/index.js
@@ -157,6 +157,11 @@ export default function VeeValidatePlugin (opts) {
   // extends the schema form props and emits
   const extend = ({ extendSchemaFormProps, extendEmits }) => {
     extendSchemaFormProps({
+      // absorb `v-model:validation` so it doesn't fall through to the root element
+      validation: {
+        type: Object,
+        default: undefined
+      },
       validationSchema: {
         type: Object,
         default: undefined

--- a/packages/plugin-vee-validate/src/types/index.d.ts
+++ b/packages/plugin-vee-validate/src/types/index.d.ts
@@ -17,6 +17,24 @@ interface PluginOptions {
   mapProps: (validation: ValidationProps) => Record<string, any>;
 }
 
+/**
+ * The form-level validation state published via the `validation` slot prop and
+ * the `update:validation` event (usable as `v-model:validation`).
+ */
+export interface FormValidationState {
+  errors: Record<string, string | undefined>;
+  values: Record<string, any>;
+  isSubmitting: boolean;
+  submitCount: number;
+  meta: {
+    valid: boolean;
+    dirty: boolean;
+    touched: boolean;
+    pending: boolean;
+    initialValues?: Record<string, any>;
+  };
+}
+
 declare const VeeValidatePlugin: (opts?: Partial<PluginOptions>) => PluginFunction
 
 export default VeeValidatePlugin

--- a/packages/plugin-vee-validate/tests/integration/integration.spec.js
+++ b/packages/plugin-vee-validate/tests/integration/integration.spec.js
@@ -55,6 +55,15 @@ const EMAIL_MESSAGE = 'Invalid Email'
 const flushVeeValidate = () => new Promise(r => setTimeout(r, 10))
 
 describe('FVL integration', () => {
+  it('does not throw when extended by a core without extendEmits', () => {
+    // Older formvuelate cores don't pass `extendEmits` to a plugin's `extend`
+    // hook. The plugin must degrade gracefully and simply skip declaring the
+    // `update:validation` event rather than crashing.
+    const plugin = veeValidatePlugin()
+
+    expect(() => plugin.extend({ extendSchemaFormProps: () => {} })).not.toThrow()
+  })
+
   it('renders error messages using validation prop', async () => {
     const schema = {
       firstName: {

--- a/packages/plugin-vee-validate/tests/integration/integration.spec.js
+++ b/packages/plugin-vee-validate/tests/integration/integration.spec.js
@@ -706,6 +706,138 @@ describe('FVL integration', () => {
     expect(wrapper.find('#error').text()).toBe('')
   })
 
+  it('emits update:validation with the initial form-level state on mount', async () => {
+    const schema = {
+      firstName: {
+        label: 'First Name',
+        component: FormText,
+        validations: yup.string().required(REQUIRED_MESSAGE)
+      }
+    }
+
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup () {
+        const formData = ref({})
+        useSchemaForm(formData)
+
+        return {
+          schema
+        }
+      }
+    })
+
+    await flushPromises()
+
+    const form = wrapper.findComponent(SchemaWithValidation)
+    const emitted = form.emitted('update:validation')
+    expect(emitted).toBeTruthy()
+
+    const state = emitted[emitted.length - 1][0]
+    expect(state).toHaveProperty('errors')
+    expect(state).toHaveProperty('values')
+    expect(state).toHaveProperty('meta')
+    expect(state).toHaveProperty('isSubmitting', false)
+    expect(state).toHaveProperty('submitCount', 0)
+  })
+
+  it('supports v-model:validation to read state outside the form', async () => {
+    const schema = {
+      firstName: {
+        label: 'First Name',
+        component: FormText,
+        validations: yup.string().required(REQUIRED_MESSAGE)
+      }
+    }
+
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
+
+    const wrapper = mount({
+      template: `
+        <div>
+          <SchemaWithValidation :schema="schema" v-model:validation="validation" />
+          <button id="outside" :disabled="!validation?.meta?.valid"></button>
+          <span id="outside-error">{{ validation?.errors?.firstName }}</span>
+        </div>
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup () {
+        const formData = ref({})
+        useSchemaForm(formData)
+        const validation = ref()
+
+        return {
+          schema,
+          validation
+        }
+      }
+    })
+
+    await flushPromises()
+    const input = wrapper.findComponent(FormText)
+    const button = wrapper.find('#outside')
+    expect(button.element.disabled).toBe(true)
+    await input.setValue('')
+    await flushPromises()
+    expect(wrapper.find('#outside-error').text()).toBe(REQUIRED_MESSAGE)
+    await input.setValue('hi')
+    await flushPromises()
+    expect(button.element.disabled).toBe(false)
+    expect(wrapper.find('#outside-error').text()).toBe('')
+  })
+
+  it('only the root schema form emits update:validation', async () => {
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
+    const schema = {
+      user: {
+        component: SchemaWithValidation,
+        model: 'subform',
+        schema: [
+          {
+            model: 'email',
+            label: 'Email',
+            component: FormText,
+            validations: yup.string().required(REQUIRED_MESSAGE)
+          }
+        ]
+      }
+    }
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup () {
+        const formData = ref({})
+        useSchemaForm(formData)
+
+        return {
+          schema
+        }
+      }
+    })
+
+    await flushPromises()
+
+    const forms = wrapper.findAllComponents(SchemaWithValidation)
+    expect(forms.length).toBeGreaterThan(1)
+
+    const emittingForms = forms.filter(form => form.emitted('update:validation'))
+    expect(emittingForms).toHaveLength(1)
+  })
+
   it('validates fields with array in nested array schema', async () => {
     const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
     const schema = {

--- a/packages/plugin-vee-validate/tests/integration/integration.spec.js
+++ b/packages/plugin-vee-validate/tests/integration/integration.spec.js
@@ -792,6 +792,10 @@ describe('FVL integration', () => {
     })
 
     await flushPromises()
+    // The `validation` prop side of `v-model:validation` is absorbed by the
+    // component and must not fall through to the root <form> as a
+    // `validation="[object Object]"` attribute.
+    expect(wrapper.find('form').attributes('validation')).toBeUndefined()
     const input = wrapper.findComponent(FormText)
     const button = wrapper.find('#outside')
     expect(button.element.disabled).toBe(true)


### PR DESCRIPTION
  Closes #288

  ## Problem

  The form-level validation state (`errors`, `values`, `isSubmitting`, `submitCount`, `meta`) is only readable through the `#beforeForm` / `#afterForm` slot props. That forces any UI reacting to validation to live inside the form's slots. As reported in #288, there's no way to read it from the parent scope to drive things that sit outside the form, like a submit button in a sticky footer or an error summary in a sidebar.

  ## Solution

  The vee-validate plugin now also emits an `update:validation` event carrying that same state object, so it can be bound with `v-model:validation` and used anywhere:

  ```html
  <template>
    <SchemaFormWithValidation
      :schema="schema"
      v-model:validation="validation"
    />

    <!-- completely outside the form -->
    <button :disabled="!validation.meta.valid">Save</button>
  </template>
```

  - Seeded with the initial state on mount, refreshed on every change.
  - Only the root schema form emits; nested schemas reuse the injected vee-validate context and stay quiet.
  - Purely additive: the existing slot props are untouched.

  To make this possible, the plugin extend hook gains an extendEmits helper (alongside extendSchemaFormProps) so a plugin can declare events on the generated SchemaForm component.

  Changes

  - SchemaFormFactory: new extendEmits(eventNames) helper; generated component declares its emits.
  - plugin-vee-validate: hoisted the validation state into a single computed (shared by the slot prop and the emit), root-only update:validation watcher, declares the emit via extendEmits.
  - Types: extendEmits added to PluginExtensionFunctions; new exported FormValidationState interface for typing the bound ref.
  - Docs: new "Accessing validation state outside the form" section in the vee-validate guide.
  - Changeset: minor bump (lockstep group -> 4.2.0).