### PR TITLE
feat: readonly elements for schema

### DIFF
--- a/.changeset/readonly-elements.md
+++ b/.changeset/readonly-elements.md
@@ -1,0 +1,6 @@
+---
+"formvuelate": minor
+"@formvuelate/plugin-vee-validate": minor
+---
+
+Add read-only schema elements. Set `readonly: true` on any element and FormVueLate will render its component and hand it the whole form model to read, but it will never wire `v-model`, so the element can't write a value back or show up in your form output. It's a clean way to drop group labels, headings, or live summaries into a schema without treating them as fields. Read-only elements are also skipped by the vee-validate plugin, so they're never registered for validation.

--- a/docs/4.x/guide/advanced-schema.md
+++ b/docs/4.x/guide/advanced-schema.md
@@ -167,6 +167,58 @@ The form model includes two default values as starting values for `aField` and `
 
 To remove this behavior and allow the form model to remain intact even when a conditional schema field is invalid, use the [`preventModelCleanupOnSchemaChange` property](#preventmodelcleanuponschemachange) on the parent `SchemaForm` component.
 
+## Read-only elements <Badge type="tip" text="4.3.0" vertical="middle" />
+
+Not everything in a form is an input. Sometimes you want to drop a heading between two groups of fields, show a little helper paragraph, or render a live summary of what the user has filled in so far. FormVueLate stays out of your way here, it does not ship any of that markup for you, but it does let you declare those pieces right alongside your fields.
+
+Mark any element with `readonly: true` and FormVueLate will render its component without wiring up `v-model`. That means the element can never write a value back into your form model, and it will never show up in your form output. It is purely there to display.
+
+So how does a read-only element show anything useful? It receives the entire form model through a `formModel` prop, ready for you to read from.
+
+```js
+const form = ref({})
+useSchemaForm(form)
+
+const schema = ref({
+  firstName: {
+    component: FormText,
+    label: 'First name'
+  },
+  lastName: {
+    component: FormText,
+    label: 'Last name'
+  },
+  summary: {
+    component: FormSummary,
+    readonly: true
+  }
+})
+```
+
+Your `FormSummary` component just declares the prop and uses it however you like.
+
+```vue
+<script setup>
+defineProps(['formModel'])
+</script>
+
+<template>
+  <p>Hello, {{ formModel.firstName }} {{ formModel.lastName }}!</p>
+</template>
+```
+
+Because the `formModel` prop is reactive, your summary updates live as the user types, all without ever becoming a field itself.
+
+A few things worth knowing:
+
+- A read-only element still needs a unique `model` value (the key you give it in an object schema, or an explicit `model` in an array schema). It is only used internally as a key, it never becomes a property on your form model.
+- A `default` on a read-only element is ignored, since read-only elements never contribute to the model.
+- The `condition` property works exactly as it does for regular fields, so you can show or hide a read-only element based on your model.
+
+:::tip
+Read-only elements are also skipped by the [vee-validate plugin](/guide/veevalidate.html), so they are never registered as fields or pulled into your validation state.
+:::
+
 ## markRaw
 
 You will notice that on our examples we use `markRaw(MyImportedComponent)

--- a/packages/formvuelate/src/SchemaField.vue
+++ b/packages/formvuelate/src/SchemaField.vue
@@ -1,6 +1,16 @@
 <template>
+  <!-- Read-only elements render their component and receive the whole form
+  model for display, but are never wired to v-model so they can't write a
+  value back or land in the form output. -->
   <component
-    v-if="schemaCondition"
+    v-if="schemaCondition && isReadonly"
+    v-bind="binds"
+    :is="component"
+    :formModel="formData"
+    class="schema-col"
+  />
+  <component
+    v-else-if="schemaCondition"
     v-bind="binds"
     :is="component"
     :modelValue="fieldValue"
@@ -10,7 +20,7 @@
 </template>
 
 <script>
-import { inject, computed } from 'vue'
+import { inject, computed, unref } from 'vue'
 import { FIND_NESTED_FORM_MODEL_PROP, SCHEMA_MODEL_PATH, FORM_MODEL, UPDATE_FORM_MODEL, INJECTED_LOCAL_COMPONENTS } from './utils/constants'
 
 export default {
@@ -58,6 +68,15 @@ export default {
       updateFormModel(formModel, props.field.model, value, path)
     }
 
+    // A read-only element opts out of model binding entirely: it can read the
+    // form data (via the `formModel` prop) but never emits an update.
+    const isReadonly = computed(() => props.field.readonly === true)
+
+    // The reactive form model object, handed to read-only elements so they can
+    // display live values. `unref` covers both the injected ref and the `{}`
+    // fallback used when no SchemaForm provides one.
+    const formData = computed(() => unref(formModel))
+
     // Render-time visibility. Conditional cleanup of formModel values for
     // hidden fields is handled by useFormModel (see features/FormModel.js),
     // because a v-if'd-out SchemaField wouldn't be mounted to run cleanup
@@ -80,7 +99,9 @@ export default {
       fieldValue,
       update,
       schemaCondition,
-      component
+      component,
+      isReadonly,
+      formData
     }
   }
 }

--- a/packages/formvuelate/src/features/FormModel.js
+++ b/packages/formvuelate/src/features/FormModel.js
@@ -61,6 +61,9 @@ export default function useFormModel (props, parsedSchema) {
    */
   if (!hasParentSchema) {
     forEachSchemaElement(parsedSchema, (el, path) => {
+      // Read-only elements never contribute a value to the form output, so a
+      // `default` on one is ignored rather than seeded into the model.
+      if (el.readonly) return
       if (!('default' in el)) return
 
       updateFormModel(formModel, el.model, el.default, path)

--- a/packages/formvuelate/tests/e2e/specs/ReadonlyElements.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/ReadonlyElements.e2e.js
@@ -1,0 +1,56 @@
+import { shallowRef } from 'vue'
+import { BaseInput, ReadOnlySummary } from '../../utils/components'
+import { SchemaFormWrapper } from '../support/helpers'
+
+describe('read-only elements', () => {
+  it('renders a read-only element that reflects the live form model', () => {
+    const schema = shallowRef({
+      firstName: {
+        component: BaseInput,
+        label: 'First name'
+      },
+      summary: {
+        component: ReadOnlySummary,
+        label: 'Summary',
+        readonly: true
+      }
+    })
+
+    cy.mount(SchemaFormWrapper({ schema }))
+
+    // Starts empty, then tracks what the user types without being an input itself.
+    cy.get('.summary-value').should('have.text', '{}')
+    cy.get('input').type('Marina')
+    cy.get('.summary-value').should('contain', 'Marina')
+  })
+
+  it('keeps the read-only element out of the form model', () => {
+    let model
+
+    const schema = shallowRef({
+      firstName: {
+        component: BaseInput,
+        label: 'First name'
+      },
+      summary: {
+        component: ReadOnlySummary,
+        label: 'Summary',
+        readonly: true,
+        // Even a `default` on a read-only element is ignored.
+        default: 'should be ignored'
+      }
+    })
+
+    cy.mount(
+      SchemaFormWrapper({
+        schema,
+        onSetup: ({ formModel }) => { model = formModel }
+      })
+    )
+
+    cy.get('input').type('Marina')
+    cy.wrap(null).should(() => {
+      expect(model.value).to.deep.equal({ firstName: 'Marina' })
+    })
+  })
+})

--- a/packages/formvuelate/tests/e2e/specs/VeeValidate.e2e.js
+++ b/packages/formvuelate/tests/e2e/specs/VeeValidate.e2e.js
@@ -2,7 +2,7 @@ import { h, ref, shallowRef } from 'vue'
 import * as yup from 'yup'
 import { SchemaFormFactory, useSchemaForm } from '../../../src/index'
 import VeeValidatePlugin from '../../../../plugin-vee-validate/src/index'
-import { BaseInput } from '../../utils/components'
+import { BaseInput, ReadOnlySummary } from '../../utils/components'
 
 const REQUIRED = 'Required'
 const EMAIL = 'Must be an email'
@@ -163,5 +163,41 @@ describe('vee-validate plugin (browser)', () => {
     cy.get('input').type('marina@test.com')
     cy.get('.outside-error').should('have.text', '')
     cy.get('button.outside-submit').should('not.be.disabled')
+  })
+
+  it('does not register read-only elements as validated fields', () => {
+    const SchemaWithValidation = SchemaFormFactory([VeeValidatePlugin()])
+
+    cy.mount({
+      components: { SchemaWithValidation },
+      setup () {
+        useSchemaForm(ref({}))
+        const schema = shallowRef([
+          {
+            model: 'email',
+            component: BaseInput,
+            label: 'Email',
+            validations: yup.string().required(REQUIRED).email(EMAIL)
+          },
+          {
+            model: 'note',
+            component: ReadOnlySummary,
+            label: 'Note',
+            readonly: true
+          }
+        ])
+        return () => h(SchemaWithValidation, { schema })
+      }
+    })
+
+    // The read-only element renders alongside the validated field...
+    cy.get('.summary').should('exist')
+
+    // ...and an invalid email surfaces exactly one error. If the read-only
+    // element had been wrapped as a field, it would register its own
+    // perpetually-empty (and failing) entry.
+    cy.get('input').type('notanemail')
+    cy.get('.error').should('have.length', 1)
+    cy.get('.error').should('have.text', EMAIL)
   })
 })

--- a/packages/formvuelate/tests/unit/SchemaField.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaField.spec.js
@@ -11,6 +11,12 @@ const FormText = {
   emits: ['update:modelValue']
 }
 
+const DisplaySummary = {
+  template: '<div class="summary" />',
+  props: ['label', 'formModel'],
+  emits: ['update:modelValue']
+}
+
 const updateFormModel = vi.fn()
 
 const SchemaFieldWrapper = (
@@ -198,5 +204,66 @@ describe('SchemaField', () => {
     // SchemaForm.spec.js — see 'cleans up the model' and
     // 'prevents model clean up if the preventModelCleanupOnSchemaChange prop
     // is true'.
+  })
+
+  describe('read-only elements', () => {
+    it('renders the component and passes the whole form model for reading', () => {
+      const model = ref({
+        firstName: 'Marina',
+        lastName: 'Mosti'
+      })
+
+      const wrapper = mount(
+        SchemaFieldWrapper({
+          field: {
+            model: 'summary',
+            component: DisplaySummary,
+            readonly: true
+          }
+        }, model)
+      )
+
+      const summary = wrapper.findComponent(DisplaySummary)
+      expect(summary.exists()).toBe(true)
+      expect(summary.props().formModel).toEqual({
+        firstName: 'Marina',
+        lastName: 'Mosti'
+      })
+    })
+
+    it('does not wire v-model, so it can never write to the form model', () => {
+      const formModel = ref({})
+
+      const wrapper = mount(
+        SchemaFieldWrapper({
+          field: {
+            model: 'summary',
+            component: DisplaySummary,
+            readonly: true
+          }
+        }, formModel, { mockUpdate: true })
+      )
+
+      wrapper.findComponent(DisplaySummary).vm.$emit('update:modelValue', 'nope')
+
+      expect(updateFormModel).not.toHaveBeenCalled()
+    })
+
+    it('still respects the condition function', () => {
+      const model = ref({ type: 'A' })
+
+      const wrapper = mount(
+        SchemaFieldWrapper({
+          field: {
+            model: 'summary',
+            component: DisplaySummary,
+            readonly: true,
+            condition: model => model.type === 'B'
+          }
+        }, model)
+      )
+
+      expect(wrapper.findComponent(DisplaySummary).exists()).toBe(false)
+    })
   })
 })

--- a/packages/formvuelate/tests/unit/SchemaForm.spec.js
+++ b/packages/formvuelate/tests/unit/SchemaForm.spec.js
@@ -218,6 +218,29 @@ describe('SchemaForm', () => {
   })
 
   describe('default schema values', () => {
+    it('does not populate the formModel from a default on a read-only element', () => {
+      const schema = {
+        firstName: {
+          component: FormText,
+          label: 'First Name',
+          default: 'Darth'
+        },
+        summary: {
+          component: FormText,
+          label: 'Summary',
+          readonly: true,
+          default: 'should be ignored'
+        }
+      }
+
+      const formModel = ref({})
+
+      mount(SchemaWrapperFactory(schema, {}, formModel))
+      expect(formModel.value).toEqual({
+        firstName: 'Darth'
+      })
+    })
+
     it('populates the formModel with the schema when created if a default prop exists', () => {
       const schema = {
         firstName: {

--- a/packages/formvuelate/tests/utils/components.js
+++ b/packages/formvuelate/tests/utils/components.js
@@ -1,5 +1,18 @@
 import { h } from 'vue'
 
+// A read-only element: it receives the whole form model via the `formModel`
+// prop and renders it for display, but never emits, so it can't write a value
+// back or land in the form output.
+export const ReadOnlySummary = {
+  props: ['label', 'formModel'],
+  render () {
+    return h('div', { class: 'summary' }, [
+      this.label ? h('strong', { class: 'summary-label' }, this.label) : null,
+      h('pre', { class: 'summary-value' }, JSON.stringify(this.formModel ?? {}))
+    ])
+  }
+}
+
 export const BaseInput = {
   props: ['label', 'modelValue', 'validation'],
   render () {

--- a/packages/plugin-vee-validate/src/index.js
+++ b/packages/plugin-vee-validate/src/index.js
@@ -64,6 +64,13 @@ export default function VeeValidatePlugin (opts) {
         return el
       }
 
+      // Read-only elements are not form fields, so they must not be wrapped in
+      // `withField`/`useField`. Doing so would register them with vee-validate
+      // and pull their (non-existent) value into the validated form state.
+      if (el && el.readonly) {
+        return el
+      }
+
       // Handles nested schemas
       // doesn't treat nested forms as fields
       // instead goes over their fields and maps them recursively

--- a/packages/plugin-vee-validate/tests/unit/plugin.spec.js
+++ b/packages/plugin-vee-validate/tests/unit/plugin.spec.js
@@ -62,4 +62,36 @@ describe('VeeValidatePlugin setup (unit)', () => {
 
     warn.mockRestore()
   })
+
+  it('leaves read-only elements unwrapped so they never register as fields', () => {
+    const Input = { name: 'Input', template: '<input/>' }
+    const Display = { name: 'Display', template: '<div/>' }
+
+    const plugin = VeeValidatePlugin()
+
+    const result = plugin(
+      {
+        parsedSchema: {
+          value: [
+            [{ model: 'name', component: Input }],
+            [{ model: 'note', component: Display, readonly: true }]
+          ]
+        },
+        formBinds: { value: { onSubmit: vi.fn() } },
+        slotBinds: { value: {} }
+      },
+      { validationSchema: undefined },
+      { emit: vi.fn() }
+    )
+
+    const enhanced = result.parsedSchema.value
+    const nameEl = enhanced[0][0]
+    const noteEl = enhanced[1][0]
+
+    // A normal field gets wrapped with the vee-validate field wrapper...
+    expect(nameEl.component.name).toBe('withFieldWrapper')
+    // ...while a read-only element keeps its original component untouched.
+    expect(noteEl.component).toBe(Display)
+    expect(noteEl.readonly).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary                                             

  Adds a `readonly: true` flag for schema elements, so a schema can render
  non-form components (group labels, headings, helper text, live summaries)
  without turning FormVueLate into a schema/markup generator.

  A read-only element renders its component and receives the whole form model
  through a `formModel` prop to read from, but it is never wired to `v-model`,
  so it can never write a value back or appear in the form output. The markup
  still comes entirely from your own component, FormVueLate ships none of it.

  Addresses the long-standing request in #230 (labels / non-field elements in
  a schema).
  
  ## How it works

  ```js
  const schema = ref({
    firstName: { component: FormText, label: 'First name' },
    summary: { component: FormSummary, readonly: true }
  })
```
  
  - SchemaField renders read-only elements through a separate branch: it
  passes the reactive form model as formModel and omits the
  :modelValue / @update:modelValue wiring.
  - useFormModel skips read-only elements when seeding default values, so
  they never contribute to the model.
  - The vee-validate plugin leaves read-only elements unwrapped, so they are
  never registered with useField / pulled into validation state.

  A read-only element still needs a unique model (the object key, or an
  explicit model in an array schema); it is used only as a render key and is
  never written to the model.